### PR TITLE
Added rule to prevent the word "means" from being considered as a key term…

### DIFF
--- a/Transcelerator/keyTermRules.xml
+++ b/Transcelerator/keyTermRules.xml
@@ -607,6 +607,7 @@
   </KeyTermRule>
   <KeyTermRule id="official; judge; magistrate" rule="MatchForRefOnly"/>
   <KeyTermRule id="tool; instrument; means" rule="MatchForRefOnly" />
+  <KeyTermRule id="property; means" rule="MatchForRefOnly" />
   <KeyTermRule id="plan, purpose, device, scheme" rule="MatchForRefOnly" />
   <KeyTermRule id="one one who shows favoritism; respecter of persons" rule="Exclude">
     <Alternate name="one who shows favoritism"/>


### PR DESCRIPTION
…in verses that do not use it in the sense of "property"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/transcelerator/22)
<!-- Reviewable:end -->
