### PR TITLE
Allow creation of Scripture Forge files when the vernacular is set to "en-US"

### DIFF
--- a/ComprehensionCheckingData/ComprehensionCheckingQuestions.cs
+++ b/ComprehensionCheckingData/ComprehensionCheckingQuestions.cs
@@ -62,17 +62,12 @@ namespace SIL.ComprehensionCheckingData
 	{
 		private int m_endChapter;
 		private int m_endVerse;
-		private string m_id;
 
 		/// <summary>
 		/// 
 		/// </summary>
 		[XmlAttribute("id")]
-		public string Id
-		{
-			get => m_id ?? Question.Single(q => q.Lang == "en-US" || q.Lang == "en").Text;
-			set => m_id = value; 
-		}
+		public string Id { get; set; }
 
 		[XmlAttribute("overview")]
 		[DefaultValue(false)]

--- a/Transcelerator/DataFileAccessor.cs
+++ b/Transcelerator/DataFileAccessor.cs
@@ -11,6 +11,7 @@
 // ---------------------------------------------------------------------------------------------
 using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using System.Text;
 using AddInSideViews;
 using SIL.Xml;
@@ -79,9 +80,14 @@ namespace SIL.Transcelerator
 
 		protected abstract void Write(DataFileId fileId, string data);
 
-		public void WriteBookSpecificData<T>(BookSpecificDataFileId fileId, string bookId, T data) =>
-			WriteBookSpecificData(fileId, bookId, XmlSerializationHelper.SerializeToString(
-				CheckDataIsXmlSerializable(data), Encoding.UTF8));
+		public void WriteBookSpecificData<T>(BookSpecificDataFileId fileId, string bookId, T data)
+		{
+			var serializedData = XmlSerializationHelper.SerializeToString(
+				CheckDataIsXmlSerializable(data), Encoding.UTF8);
+            if (serializedData == null)
+                throw new SerializationException($"An error occurred serializing {bookId} data for {fileId}.");
+			WriteBookSpecificData(fileId, bookId, serializedData);
+		}
 
 		protected abstract void WriteBookSpecificData(BookSpecificDataFileId fileId, string bookId, string data);
 

--- a/Transcelerator/TransceleratorTests/TransceleratorTests.csproj
+++ b/Transcelerator/TransceleratorTests/TransceleratorTests.csproj
@@ -270,6 +270,10 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\ComprehensionCheckingData\ComprehensionCheckingData.csproj">
+      <Project>{c6474f83-4e0a-462f-bd87-883c197f1be6}</Project>
+      <Name>ComprehensionCheckingData</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\SilUtils\SilUtils.csproj">
       <Project>{4E4CE84F-BB35-416A-8E4F-B8C096DA32B7}</Project>
       <Name>SilUtils</Name>

--- a/Transcelerator/TranslatablePhrase.cs
+++ b/Transcelerator/TranslatablePhrase.cs
@@ -570,6 +570,9 @@ namespace SIL.Transcelerator
 
 		[Browsable(false)]
 		public IEnumerable<string> AlternateForms => QuestionInfo?.AlternativeForms;
+
+		public string ImmutableKey => IsUserAdded ? QuestionInfo.Id :
+			QuestionInfo?.Alternatives?.FirstOrDefault(a => a.IsKey)?.Text ?? OriginalPhrase;
 		#endregion
 
 		#region Public/internal methods (and the indexer which is really more like a property, but Tim wants it in this region)

--- a/TxlCore/ILocalizationsProvider.cs
+++ b/TxlCore/ILocalizationsProvider.cs
@@ -1,0 +1,8 @@
+﻿namespace SIL.Transcelerator.Localization
+{
+	public interface ILocalizationsProvider
+	{
+		string Locale { get; }
+		bool TryGetLocalizedString(UIDataString key, out string localized);
+	}
+}

--- a/TxlCore/LocalizationsFileAccessor.cs
+++ b/TxlCore/LocalizationsFileAccessor.cs
@@ -19,7 +19,7 @@ using System.Xml.Serialization;
 
 namespace SIL.Transcelerator.Localization
 {
-	public class LocalizationsFileAccessor
+	public class LocalizationsFileAccessor : ILocalizationsProvider
 	{
 		private Localizations m_xliffRoot;
 		protected Localizations XliffRoot => m_xliffRoot;

--- a/TxlCore/TxlCore.csproj
+++ b/TxlCore/TxlCore.csproj
@@ -110,6 +110,7 @@
   <ItemGroup>
     <Compile Include="AlternativeForm.cs" />
     <Compile Include="Category.cs" />
+    <Compile Include="ILocalizationsProvider.cs" />
     <Compile Include="IRefRange.cs" />
     <Compile Include="ITranslatablePhrase.cs" />
     <Compile Include="LocalizationsFileAccessor.cs" />


### PR DESCRIPTION
Changed the way the key is determined for the SF files and suppressed output of the built-in "en-US" version of the question if the vernacular is set to "en-US".
Also, did some refactoring to allow the method in question to be tested.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/transcelerator/28)
<!-- Reviewable:end -->
