### PR TITLE
TXL-226: Fixed Installer to create the localization folder(s) unconditionally

### DIFF
--- a/DistFiles/localization/Transcelerator.es.xlf
+++ b/DistFiles/localization/Transcelerator.es.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns:sil="http://sil.org/software/XLiff" xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" product-version="1.5.0.0" original="Transcelerator.dll" datatype="plaintext" target-language="es-ES">
+  <file source-language="en" product-version="1.5.4" original="Transcelerator.dll" datatype="plaintext" target-language="es-ES">
     <body>
       <trans-unit id="AddRenderingDlg.WindowTitle">
         <source xml:lang="en">Add Rendering</source>
@@ -51,7 +51,7 @@
       <trans-unit id="EditQuestionDlg.m_lblQuestionToUse">
         <source xml:lang="en">Question to Use:</source>
         <note>ID: EditQuestionDlg.m_lblQuestionToUse</note>
-        <target xml:lang="es-ES" state="needs-translation">Question to Use:</target>
+        <target xml:lang="es-ES" state="translated">Pregunta a usar:</target>
       </trans-unit>
       <trans-unit id="General.ErrorStarting">
         <source xml:lang="en">Error occurred attempting to start {0}: </source>
@@ -127,7 +127,7 @@
       <trans-unit id="GenerateScriptDlg.lblStyleSpecification">
         <source xml:lang="en">Where to Specify Styles:</source>
         <note>ID: GenerateScriptDlg.lblStyleSpecification</note>
-        <target xml:lang="es-ES" state="needs-translation">Where to Specify Styles:</target>
+        <target xml:lang="es-ES" state="translated">Dónde especificar los estilos:</target>
       </trans-unit>
       <trans-unit id="GenerateScriptDlg.lblUntranslatedQuestions">
         <source xml:lang="en">How to Handle Untranslated Questions:</source>
@@ -353,7 +353,7 @@
         <source xml:lang="en">&amp;Advanced</source>
         <note>ID: MainWindow.Menu.Advanced</note>
         <note>To control which character will be the mnemonic key (underlined when the user presses the ALT key), put the ampersand before the desired character.</note>
-        <target xml:lang="es-ES" state="translated">&amp;Avanzado</target>
+        <target xml:lang="es-ES" state="translated">A&amp;vanzado</target>
       </trans-unit>
       <trans-unit id="MainWindow.Menu.Advanced.BiblicalTermsRenderingSelectionRules">
         <source xml:lang="en">Biblical Terms &amp;Rendering Selection Rules...</source>
@@ -389,7 +389,7 @@
         <source xml:lang="en">&amp;Next Untranslated Question</source>
         <note>ID: MainWindow.Menu.Edit.NextUntranslatedQuestion</note>
         <note>To control which character will be the mnemonic key (underlined when the user presses the ALT key), put the ampersand before the desired character.</note>
-        <target xml:lang="es-ES" state="translated">&amp;Siguiente pregunta sin traducir</target>
+        <target xml:lang="es-ES" state="translated">Pregunta &amp;siguiente no traducido</target>
       </trans-unit>
       <trans-unit id="MainWindow.Menu.Edit.Paste">
         <source xml:lang="en">&amp;Paste</source>
@@ -484,13 +484,13 @@
         <source xml:lang="en">&amp;Generated Translation Details</source>
         <note>ID: MainWindow.Menu.GeneratedTranslationDetails</note>
         <note>To control which character will be the mnemonic key (underlined when the user presses the ALT key), put the ampersand before the desired character.</note>
-        <target xml:lang="es-ES" state="needs-translation">&amp;Generated Translation Details</target>
+        <target xml:lang="es-ES" state="translated">&amp;Detalles de la traducción generados</target>
       </trans-unit>
       <trans-unit id="MainWindow.Menu.Help">
         <source xml:lang="en">&amp;Help</source>
         <note>ID: MainWindow.Menu.Help</note>
         <note>To control which character will be the mnemonic key (underlined when the user presses the ALT key), put the ampersand before the desired character.</note>
-        <target xml:lang="es-ES" state="translated">&amp;Ayuda</target>
+        <target xml:lang="es-ES" state="translated">A&amp;yuda</target>
       </trans-unit>
       <trans-unit id="MainWindow.Menu.Help.About">
         <source xml:lang="en">&amp;About Transcelerator</source>
@@ -514,7 +514,7 @@
         <source xml:lang="en">&amp;Biblical Terms Pane</source>
         <note>ID: MainWindow.Menu.View.BiblicalTermsPane</note>
         <note>To control which character will be the mnemonic key (underlined when the user presses the ALT key), put the ampersand before the desired character.</note>
-        <target xml:lang="es-ES" state="translated">&amp;Panel de vocablos bíblicos</target>
+        <target xml:lang="es-ES" state="translated">Panel de vocablos &amp;bíblicos</target>
       </trans-unit>
       <trans-unit id="MainWindow.Menu.View.DisplayLanguage">
         <source xml:lang="en">&amp;Display Language</source>
@@ -568,6 +568,11 @@
         <source xml:lang="en">Save changes?</source>
         <note>ID: MainWindow.SaveChangesMessageCaption</note>
         <target xml:lang="es-ES" state="translated">¿Guardar cambios?</target>
+      </trans-unit>
+      <trans-unit id="MainWindow.UNSQuestionsDialog.toolStripMenuItem1">
+        <source xml:lang="en">&amp;More...</source>
+        <note>ID: MainWindow.UNSQuestionsDialog.toolStripMenuItem1</note>
+        <target xml:lang="es-ES" state="translated">&amp;Más...</target>
       </trans-unit>
       <trans-unit id="MainWindow.UntranslatedQuestionsWarning">
         <source xml:lang="en">There are {0} questions in the selected range that do not have confirmed translations. Do you want to continue? (Untranslated questions will be excluded.)</source>
@@ -661,12 +666,35 @@
         <source xml:lang="en">Show Questions with Terms &amp;Missing Renderings</source>
         <note>ID: MainWindow.mnuShowPhrasesWithMissingKtRenderings</note>
         <note>To control which character will be the mnemonic key (underlined when the user presses the ALT key), put the ampersand before the desired character.</note>
-        <target xml:lang="es-ES" state="translated">&amp;Mostrar preguntas con vocablos sin traduccion</target>
+        <target xml:lang="es-ES" state="translated">&amp;Mostrar preguntas con vocablos sin traducción</target>
       </trans-unit>
       <trans-unit id="MainWindow.toolStripLabelQuestionFilter">
         <source xml:lang="en">Question Filter:</source>
         <note>ID: MainWindow.toolStripLabelQuestionFilter</note>
         <target xml:lang="es-ES" state="translated">Filtro de preguntas:</target>
+      </trans-unit>
+      <trans-unit id="MoreUiLanguagesDlg.Download">
+        <source xml:lang="en">Download the latest Installer.</source>
+        <note>ID: MoreUiLanguagesDlg.Download</note>
+        <note>Sentence that will be formatted as a hyperlink and appended to "MoreUiLanguagesDlg.m_linkLabelAddDisplayLanguageUsingInstaller"</note>
+        <target xml:lang="es-ES" state="translated">Descarga el último instalador.</target>
+      </trans-unit>
+      <trans-unit id="MoreUiLanguagesDlg.WindowTitle">
+        <source xml:lang="en">More Display Languages</source>
+        <note>ID: MoreUiLanguagesDlg.WindowTitle</note>
+        <target xml:lang="es-ES" state="translated">Más Idiomas de interfaz</target>
+      </trans-unit>
+      <trans-unit id="MoreUiLanguagesDlg.m_linkLabelAddDisplayLanguageUsingInstaller">
+        <source xml:lang="en">If the langauge you would like to see is not available on the {0} menu, use the latest Installer to see if it is available to select.</source>
+        <note>ID: MoreUiLanguagesDlg.m_linkLabelAddDisplayLanguageUsingInstaller</note>
+        <note>Param is the name (as localized) of the "Display Language" menu</note>
+        <target xml:lang="es-ES" state="translated">Si el idioma que desea ver no está disponible en el menú {0}, utilice el último instalador para ver si está disponible para seleccionar.</target>
+      </trans-unit>
+      <trans-unit id="MoreUiLanguagesDlg.m_linkLabelCrowdinInformation">
+        <source xml:lang="en">{0} uses {1} to manage the localization effort for strings displayed in its user interface and for the source questions to be translated. If you would like to contribute translations or request the addition of another display language, please make your request via {1}.</source>
+        <note>ID: MoreUiLanguagesDlg.m_linkLabelCrowdinInformation</note>
+        <note>Param 0: "Transcelerator" (plugin name); Param 1: "Crowdin" (website) - will be formatted as a hyperlink to crowdin.com</note>
+        <target xml:lang="es-ES" state="translated">{0} usa {1} para administrar la obra de localizar su interfaz de usuario y para traducir las preguntas de fuente. Si desea contribuir con las traducciones o solicitar la adición de otro idioma de interfaz, por favor haga su solicitud a través de {1}.</target>
       </trans-unit>
       <trans-unit id="NewQuestionDlg.NoExistingQuestions">
         <source xml:lang="en">There are no existing {0} questions for {1}.</source>
@@ -784,7 +812,7 @@
       <trans-unit id="PhraseSubstitutionsDlg.Replacements.WordOrPhraseToReplace">
         <source xml:lang="en">Word or Phrase to Replace</source>
         <note>ID: PhraseSubstitutionsDlg.Replacements.WordOrPhraseToReplace</note>
-        <target xml:lang="es-ES" state="needs-translation">Word or Phrase to Replace</target>
+        <target xml:lang="es-ES" state="translated">Palabra o frase a reemplazar</target>
       </trans-unit>
       <trans-unit id="PhraseSubstitutionsDlg.WindowTitle">
         <source xml:lang="en">Question Adjustments</source>
@@ -809,22 +837,22 @@
       <trans-unit id="PhraseSubstitutionsDlg.lblMatchPrefix">
         <source xml:lang="en">Match a prefix</source>
         <note>ID: PhraseSubstitutionsDlg.lblMatchPrefix</note>
-        <target xml:lang="es-ES" state="needs-translation">Match a prefix</target>
+        <target xml:lang="es-ES" state="translated">Coincide con un prefijo</target>
       </trans-unit>
       <trans-unit id="PhraseSubstitutionsDlg.lblMaxMatch">
         <source xml:lang="en">Maximum times to match</source>
         <note>ID: PhraseSubstitutionsDlg.lblMaxMatch</note>
-        <target xml:lang="es-ES" state="needs-translation">Maximum times to match</target>
+        <target xml:lang="es-ES" state="translated">Las veces máximas para coincidir</target>
       </trans-unit>
       <trans-unit id="PhraseSubstitutionsDlg.lblSuffix">
         <source xml:lang="en">Match a suffix</source>
         <note>ID: PhraseSubstitutionsDlg.lblSuffix</note>
-        <target xml:lang="es-ES" state="needs-translation">Match a suffix</target>
+        <target xml:lang="es-ES" state="translated">Coincide con un sufijo</target>
       </trans-unit>
       <trans-unit id="PhraseSubstitutionsDlg.m_btnMatchSingleWord">
         <source xml:lang="en">Match any single word</source>
         <note>ID: PhraseSubstitutionsDlg.m_btnMatchSingleWord</note>
-        <target xml:lang="es-ES" state="needs-translation">Match any single word</target>
+        <target xml:lang="es-ES" state="translated">Coincide con cualquier palabra</target>
       </trans-unit>
       <trans-unit id="PhraseSubstitutionsDlg.m_grpPreview">
         <source xml:lang="en">Preview Sample Question</source>
@@ -1026,7 +1054,7 @@
       <trans-unit id="RulesWizardDlg.grpSelectRendering">
         <source xml:lang="en">Select the rendering of the biblical term that meets the following condition:</source>
         <note>ID: RulesWizardDlg.grpSelectRendering</note>
-        <target xml:lang="es-ES" state="needs-translation">Select the rendering of the biblical term that meets the following condition:</target>
+        <target xml:lang="es-ES" state="translated">Seleccione la traducción del término bíblico que cumpla con la siguiente condición:</target>
       </trans-unit>
       <trans-unit id="RulesWizardDlg.m_lblFollowingWordExample">
         <source xml:lang="en">Example: </source>
@@ -1070,13 +1098,13 @@
         <source xml:lang="en">&amp;Vernacular prefix:</source>
         <note>ID: RulesWizardDlg.m_lblRenderingConditionVernPrefix</note>
         <note>To control which character will be the mnemonic key (underlined when the user presses the ALT key), put the ampersand before the desired character.</note>
-        <target xml:lang="es-ES" state="needs-translation">&amp;Vernacular prefix:</target>
+        <target xml:lang="es-ES" state="translated">&amp; Prefijo vernacular:</target>
       </trans-unit>
       <trans-unit id="RulesWizardDlg.m_lblRenderingConditionVernSuffix">
         <source xml:lang="en">&amp;Vernacular suffix:</source>
         <note>ID: RulesWizardDlg.m_lblRenderingConditionVernSuffix</note>
         <note>To control which character will be the mnemonic key (underlined when the user presses the ALT key), put the ampersand before the desired character.</note>
-        <target xml:lang="es-ES" state="needs-translation">&amp;Vernacular suffix:</target>
+        <target xml:lang="es-ES" state="translated">&amp; Subfijo vernacular:</target>
       </trans-unit>
       <trans-unit id="RulesWizardDlg.m_lblRuleDescription">
         <source xml:lang="en">Rule description:</source>
@@ -1120,7 +1148,7 @@
         <source xml:lang="en">Term has a specific &amp;prefix</source>
         <note>ID: RulesWizardDlg.m_rdoPrefix</note>
         <note>To control which character will be the mnemonic key (underlined when the user presses the ALT key), put the ampersand before the desired character.</note>
-        <target xml:lang="es-ES" state="translated">El vocablo tiene un prefijo &amp;específico</target>
+        <target xml:lang="es-ES" state="translated">El vocablo tiene un &amp;prefijo específico</target>
       </trans-unit>
       <trans-unit id="RulesWizardDlg.m_rdoRenderingHasPrefix">
         <source xml:lang="en">Rendering has a specific p&amp;refix</source>
@@ -1138,7 +1166,7 @@
         <source xml:lang="en">Term has a specific &amp;suffix</source>
         <note>ID: RulesWizardDlg.m_rdoSuffix</note>
         <note>To control which character will be the mnemonic key (underlined when the user presses the ALT key), put the ampersand before the desired character.</note>
-        <target xml:lang="es-ES" state="translated">El vocablo tiene un sufijo &amp;específico</target>
+        <target xml:lang="es-ES" state="translated">El vocablo tiene un &amp;sufijo específico</target>
       </trans-unit>
       <trans-unit id="RulesWizardDlg.m_rdoUserDefinedQuestionCriteria">
         <source xml:lang="en">&amp;User-defined condition</source>

--- a/DistFiles/localization/Transcelerator.es.xlf
+++ b/DistFiles/localization/Transcelerator.es.xlf
@@ -685,7 +685,7 @@
         <target xml:lang="es-ES" state="translated">Más Idiomas de interfaz</target>
       </trans-unit>
       <trans-unit id="MoreUiLanguagesDlg.m_linkLabelAddDisplayLanguageUsingInstaller">
-        <source xml:lang="en">If the langauge you would like to see is not available on the {0} menu, use the latest Installer to see if it is available to select.</source>
+        <source xml:lang="en">If the language you would like to see is not available on the {0} menu, use the latest Installer to see if it is available to select.</source>
         <note>ID: MoreUiLanguagesDlg.m_linkLabelAddDisplayLanguageUsingInstaller</note>
         <note>Param is the name (as localized) of the "Display Language" menu</note>
         <target xml:lang="es-ES" state="translated">Si el idioma que desea ver no está disponible en el menú {0}, utilice el último instalador para ver si está disponible para seleccionar.</target>

--- a/Installer/Installer.wxs
+++ b/Installer/Installer.wxs
@@ -297,6 +297,13 @@ http://blogs.msdn.com/robmen/archive/2003/10/04/56479.aspx -->
             </Component>
         </ComponentGroup>
 
+        <ComponentGroup Id="COMPONENTSFORP7PLUGINLOCALIZATION_fr" Directory="INSTALLDIR7_LOCALIZATION"
+                        Source="..\DistFiles\localization">
+            <Component Id="Transcelerator.fr.xlf_P7" Guid="{217F9470-C16F-4B1D-9DD4-98AD5A4288CC}">
+                <File Id="Transcelerator.fr.xlf_P7" ShortName="frp8.xlf" KeyPath="yes" Name="Transcelerator.fr.xlf" />
+            </Component>
+        </ComponentGroup>
+
         <ComponentGroup Id="COMPONENTSFORP7TestPLUGIN" Directory="INSTALLDIR7TEST"
                         Source="..\Transcelerator\bin\x86\Release">
             <Component Guid="{6517fe81-0e7f-42ed-bdbc-0d5041bf6f46}">
@@ -445,6 +452,13 @@ http://blogs.msdn.com/robmen/archive/2003/10/04/56479.aspx -->
             </Component>
         </ComponentGroup>
 
+        <ComponentGroup Id="COMPONENTSFORP7TestPLUGINLOCALIZATION_fr" Directory="INSTALLDIR7TEST_LOCALIZATION"
+                        Source="..\DistFiles\localization">
+            <Component Id="Transcelerator.fr.xlf_P7Test" Guid="{3BC8ABAF-7CE4-41E6-80AD-8EFE86D13D89}">
+                <File Id="Transcelerator.fr.xlf_P7Test" ShortName="frp8.xlf" KeyPath="yes" Name="Transcelerator.fr.xlf" />
+            </Component>
+        </ComponentGroup>
+
         <ComponentGroup Id="COMPONENTSFORP8PLUGIN" Directory="INSTALLDIR8" Source="..\Transcelerator\bin\x86\Release">
             <Component Guid="{91562ae0-0a28-4f0c-9345-95464e109314}">
                 <File Id="Transcelerator.dll_P8" ShortName="c9c8ckpm.dll" KeyPath="yes" Name="Transcelerator.dll" />
@@ -580,6 +594,13 @@ http://blogs.msdn.com/robmen/archive/2003/10/04/56479.aspx -->
             <Component Id="LocalizedPhrases_fr.xlf_P8" Guid="{6515FF29-1D71-4EF2-8F6D-11193EC263D3}">
                 <File Id="LocalizedPhrases_fr.xlf_P8" ShortName="hsbywryt.xlf" KeyPath="yes"
                       Name="LocalizedPhrases-fr.xlf" />
+            </Component>
+        </ComponentGroup>
+
+        <ComponentGroup Id="COMPONENTSFORP8PLUGINLOCALIZATION_fr" Directory="INSTALLDIR8_LOCALIZATION"
+                        Source="..\DistFiles\localization">
+            <Component Id="Transcelerator.fr.xlf_P8" Guid="{EA03A58B-1A90-4F98-9601-9B8B30A4B6A7}">
+                <File Id="Transcelerator.fr.xlf_P8" ShortName="frp8.xlf" KeyPath="yes" Name="Transcelerator.fr.xlf" />
             </Component>
         </ComponentGroup>
 
@@ -721,9 +742,19 @@ http://blogs.msdn.com/robmen/archive/2003/10/04/56479.aspx -->
             </Component>
         </ComponentGroup>
 
+        <ComponentGroup Id="COMPONENTSFORP9PLUGINLOCALIZATION_fr" Directory="INSTALLDIR9_LOCALIZATION"
+                        Source="..\DistFiles\localization">
+            <Component Id="Transcelerator.fr.xlf_P9" Guid="{416F2724-5F68-46E8-9D60-647BFCEEF769}">
+                <File Id="Transcelerator.fr.xlf_P9" ShortName="frp9.xlf" KeyPath="yes" Name="Transcelerator.fr.xlf" />
+            </Component>
+        </ComponentGroup>
+
         <Feature Id="PluginFeature_P7" Level="0" Title="Plugin for Paratext 7.5" AllowAdvertise="no">
             <Condition Level="1"><![CDATA[PARATEXT75100ORGREATER AND UPDATEP7PLUGINCACHE]]></Condition>
             <ComponentGroupRef Id="COMPONENTSFORP7PLUGIN" />
+            <Component Id="CreateP7LocalizationFolder" Directory="INSTALLDIR7_LOCALIZATION" Guid="{4C5A3D2E-13AD-4CE1-8496-35D8D37D4C95}">
+				<CreateFolder />
+			</Component>
             <Feature Id="Localization_P7" Level="1" Title="Localizations" InstallDefault="followParent"
                      AllowAdvertise="no">
                 <Feature Id="Localization_P7_es" Level="1" Title="español" InstallDefault="followParent"
@@ -738,6 +769,7 @@ http://blogs.msdn.com/robmen/archive/2003/10/04/56479.aspx -->
                 <Feature Id="Localization_P7_fr" Level="1" Title="français" InstallDefault="followParent"
                          AllowAdvertise="no">
                     <ComponentGroupRef Id="COMPONENTSFORP7PLUGIN_fr" />
+					<ComponentGroupRef Id="COMPONENTSFORP7PLUGINLOCALIZATION_fr" />
                 </Feature>
             </Feature>
         </Feature>
@@ -745,6 +777,9 @@ http://blogs.msdn.com/robmen/archive/2003/10/04/56479.aspx -->
         <Feature Id="PluginFeature_P7Test" Level="0" Title="Plugin for Paratext 7.6 (pre-release)" AllowAdvertise="no">
             <Condition Level="1"><![CDATA[PARATEXT7TEST AND UPDATEP7TESTPLUGINCACHE]]></Condition>
             <ComponentGroupRef Id="COMPONENTSFORP7TestPLUGIN" />
+			<Component Id="CreateP7TestLocalizationFolder" Directory="INSTALLDIR7TEST_LOCALIZATION" Guid="{08E9C8E8-18F1-48C3-AA5C-9E65C0D1F2E3}">
+				<CreateFolder />
+			</Component>
             <Feature Id="Localization_P7Test" Level="1" Title="Localizations" InstallDefault="followParent"
                      AllowAdvertise="no">
                 <Feature Id="Localization_P7Test_es" Level="1" Title="español" InstallDefault="followParent"
@@ -759,6 +794,7 @@ http://blogs.msdn.com/robmen/archive/2003/10/04/56479.aspx -->
                 <Feature Id="Localization_P7Test_fr" Level="1" Title="français" InstallDefault="followParent"
                          AllowAdvertise="no">
                     <ComponentGroupRef Id="COMPONENTSFORP7TestPLUGIN_fr" />
+					<ComponentGroupRef Id="COMPONENTSFORP7TestPLUGINLOCALIZATION_fr" />
                 </Feature>
             </Feature>
         </Feature>
@@ -766,6 +802,9 @@ http://blogs.msdn.com/robmen/archive/2003/10/04/56479.aspx -->
         <Feature Id="PluginFeature_P8" Level="0" Title="Plugin for Paratext 8" AllowAdvertise="no">
             <Condition Level="1"><![CDATA[PARATEXT8 AND UPDATEP8PLUGINCACHE]]></Condition>
             <ComponentGroupRef Id="COMPONENTSFORP8PLUGIN" />
+			<Component Id="CreateP8LocalizationFolder" Directory="INSTALLDIR8_LOCALIZATION" Guid="{6747B599-E88C-42F0-8742-316CC633125A}">
+				<CreateFolder />
+			</Component>
             <Feature Id="Localization_P8" Level="1" Title="Localizations" InstallDefault="followParent"
                      AllowAdvertise="no">
                 <Feature Id="Localization_P8_es" Level="1" Title="español" InstallDefault="followParent"
@@ -780,6 +819,7 @@ http://blogs.msdn.com/robmen/archive/2003/10/04/56479.aspx -->
                 <Feature Id="Localization_P8_fr" Level="1" Title="français" InstallDefault="followParent"
                          AllowAdvertise="no">
                     <ComponentGroupRef Id="COMPONENTSFORP8PLUGIN_fr" />
+                    <ComponentGroupRef Id="COMPONENTSFORP8PLUGINLOCALIZATION_fr" />
                 </Feature>
             </Feature>
         </Feature>
@@ -787,6 +827,9 @@ http://blogs.msdn.com/robmen/archive/2003/10/04/56479.aspx -->
         <Feature Id="PluginFeature_P9" Level="0" Title="Plugin for Paratext 9" AllowAdvertise="no">
             <Condition Level="1"><![CDATA[PARATEXT9 AND UPDATEP9PLUGINCACHE]]></Condition>
             <ComponentGroupRef Id="COMPONENTSFORP9PLUGIN" />
+			<Component Id="CreateP9LocalizationFolder" Directory="INSTALLDIR9_LOCALIZATION" Guid="{FFFD2FB8-E7EE-4806-8910-96B2D166FD14}">
+				<CreateFolder />
+			</Component>
             <Feature Id="Localization_P9" Level="1" Title="Localizations" InstallDefault="followParent"
                      AllowAdvertise="no">
                 <Feature Id="Localization_P9_es" Level="1" Title="español" InstallDefault="followParent"
@@ -801,6 +844,7 @@ http://blogs.msdn.com/robmen/archive/2003/10/04/56479.aspx -->
                 <Feature Id="Localization_P9_fr" Level="1" Title="français" InstallDefault="followParent"
                          AllowAdvertise="no">
                     <ComponentGroupRef Id="COMPONENTSFORP9PLUGIN_fr" />
+                    <ComponentGroupRef Id="COMPONENTSFORP9PLUGINLOCALIZATION_fr" />
                 </Feature>
             </Feature>
         </Feature>

--- a/Transcelerator.sln.DotSettings
+++ b/Transcelerator.sln.DotSettings
@@ -3,6 +3,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=UI/@EntryIndexedValue">UI</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=analytics/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=BBBCCCVVV/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Crowdin/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=endref/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Lectionary/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=linklbl/@EntryIndexedValue">True</s:Boolean>

--- a/Transcelerator/MoreUiLanguagesDlg.Designer.cs
+++ b/Transcelerator/MoreUiLanguagesDlg.Designer.cs
@@ -97,13 +97,13 @@
 			this.m_linkLabelAddDisplayLanguageUsingInstaller.Size = new System.Drawing.Size(617, 32);
 			this.m_linkLabelAddDisplayLanguageUsingInstaller.TabIndex = 2;
 			this.m_linkLabelAddDisplayLanguageUsingInstaller.Tag = "https://software.sil.org/transcelerator/download/";
-			this.m_linkLabelAddDisplayLanguageUsingInstaller.Text = "If the langauge you would like to see is not available on the {0} menu, use the l" +
+			this.m_linkLabelAddDisplayLanguageUsingInstaller.Text = "If the language you would like to see is not available on the {0} menu, use the l" +
     "atest Installer to see if it is available to select.";
 			this.m_linkLabelAddDisplayLanguageUsingInstaller.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.HandleLinkClicked);
 			// 
 			// l10NSharpExtender1
 			// 
-			this.l10NSharpExtender1.LocalizationManagerId = null;
+			this.l10NSharpExtender1.LocalizationManagerId = "Transcelerator";
 			this.l10NSharpExtender1.PrefixForNewItems = null;
 			// 
 			// MoreUiLanguagesDlg

--- a/Transcelerator/MoreUiLanguagesDlg.Designer.cs
+++ b/Transcelerator/MoreUiLanguagesDlg.Designer.cs
@@ -1,0 +1,139 @@
+﻿namespace SIL.Transcelerator
+{
+	partial class MoreUiLanguagesDlg
+	{
+		/// <summary>
+		/// Required designer variable.
+		/// </summary>
+		private System.ComponentModel.IContainer components = null;
+
+		/// <summary>
+		/// Clean up any resources being used.
+		/// </summary>
+		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && (components != null))
+			{
+				components.Dispose();
+			}
+			base.Dispose(disposing);
+		}
+
+		#region Windows Form Designer generated code
+
+		/// <summary>
+		/// Required method for Designer support - do not modify
+		/// the contents of this method with the code editor.
+		/// </summary>
+		private void InitializeComponent()
+		{
+			this.components = new System.ComponentModel.Container();
+			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MoreUiLanguagesDlg));
+			this.m_btnOk = new System.Windows.Forms.Button();
+			this.m_linkLabelCrowdinInformation = new System.Windows.Forms.LinkLabel();
+			this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
+			this.m_linkLabelAddDisplayLanguageUsingInstaller = new System.Windows.Forms.LinkLabel();
+			this.l10NSharpExtender1 = new L10NSharp.UI.L10NSharpExtender(this.components);
+			this.flowLayoutPanel1.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)(this.l10NSharpExtender1)).BeginInit();
+			this.SuspendLayout();
+			// 
+			// m_btnOk
+			// 
+			this.m_btnOk.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+			this.m_btnOk.DialogResult = System.Windows.Forms.DialogResult.OK;
+			this.l10NSharpExtender1.SetLocalizableToolTip(this.m_btnOk, null);
+			this.l10NSharpExtender1.SetLocalizationComment(this.m_btnOk, null);
+			this.l10NSharpExtender1.SetLocalizingId(this.m_btnOk, "Common.OK");
+			this.m_btnOk.Location = new System.Drawing.Point(284, 133);
+			this.m_btnOk.Margin = new System.Windows.Forms.Padding(4);
+			this.m_btnOk.Name = "m_btnOk";
+			this.m_btnOk.Size = new System.Drawing.Size(100, 28);
+			this.m_btnOk.TabIndex = 2;
+			this.m_btnOk.Text = "OK";
+			this.m_btnOk.UseVisualStyleBackColor = true;
+			// 
+			// m_linkLabelCrowdinInformation
+			// 
+			this.m_linkLabelCrowdinInformation.AutoSize = true;
+			this.m_linkLabelCrowdinInformation.LinkArea = new System.Windows.Forms.LinkArea(9, 3);
+			this.l10NSharpExtender1.SetLocalizableToolTip(this.m_linkLabelCrowdinInformation, null);
+			this.l10NSharpExtender1.SetLocalizationComment(this.m_linkLabelCrowdinInformation, "Param 0: \"Transcelerator\" (plugin name); Param 1: \"Crowdin\" (website) - will be f" +
+        "ormatted as a hyperlink to crowdin.com");
+			this.l10NSharpExtender1.SetLocalizingId(this.m_linkLabelCrowdinInformation, "MoreUiLanguagesDlg.m_linkLabelCrowdinInformation");
+			this.m_linkLabelCrowdinInformation.Location = new System.Drawing.Point(3, 32);
+			this.m_linkLabelCrowdinInformation.Name = "m_linkLabelCrowdinInformation";
+			this.m_linkLabelCrowdinInformation.Size = new System.Drawing.Size(619, 49);
+			this.m_linkLabelCrowdinInformation.TabIndex = 0;
+			this.m_linkLabelCrowdinInformation.TabStop = true;
+			this.m_linkLabelCrowdinInformation.Tag = "https://crowdin.com/project/transcelerator";
+			this.m_linkLabelCrowdinInformation.Text = resources.GetString("m_linkLabelCrowdinInformation.Text");
+			this.m_linkLabelCrowdinInformation.UseCompatibleTextRendering = true;
+			this.m_linkLabelCrowdinInformation.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.HandleLinkClicked);
+			// 
+			// flowLayoutPanel1
+			// 
+			this.flowLayoutPanel1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+			this.flowLayoutPanel1.AutoSize = true;
+			this.flowLayoutPanel1.Controls.Add(this.m_linkLabelAddDisplayLanguageUsingInstaller);
+			this.flowLayoutPanel1.Controls.Add(this.m_linkLabelCrowdinInformation);
+			this.flowLayoutPanel1.Location = new System.Drawing.Point(16, 15);
+			this.flowLayoutPanel1.Name = "flowLayoutPanel1";
+			this.flowLayoutPanel1.Size = new System.Drawing.Size(628, 100);
+			this.flowLayoutPanel1.TabIndex = 3;
+			// 
+			// m_linkLabelAddDisplayLanguageUsingInstaller
+			// 
+			this.m_linkLabelAddDisplayLanguageUsingInstaller.AutoSize = true;
+			this.m_linkLabelAddDisplayLanguageUsingInstaller.LinkArea = new System.Windows.Forms.LinkArea(0, 0);
+			this.l10NSharpExtender1.SetLocalizableToolTip(this.m_linkLabelAddDisplayLanguageUsingInstaller, null);
+			this.l10NSharpExtender1.SetLocalizationComment(this.m_linkLabelAddDisplayLanguageUsingInstaller, "Param is the name (as localized) of the \"Display Language\" menu");
+			this.l10NSharpExtender1.SetLocalizingId(this.m_linkLabelAddDisplayLanguageUsingInstaller, "MoreUiLanguagesDlg.m_linkLabelAddDisplayLanguageUsingInstaller");
+			this.m_linkLabelAddDisplayLanguageUsingInstaller.Location = new System.Drawing.Point(3, 0);
+			this.m_linkLabelAddDisplayLanguageUsingInstaller.Name = "m_linkLabelAddDisplayLanguageUsingInstaller";
+			this.m_linkLabelAddDisplayLanguageUsingInstaller.Size = new System.Drawing.Size(617, 32);
+			this.m_linkLabelAddDisplayLanguageUsingInstaller.TabIndex = 2;
+			this.m_linkLabelAddDisplayLanguageUsingInstaller.Tag = "https://software.sil.org/transcelerator/download/";
+			this.m_linkLabelAddDisplayLanguageUsingInstaller.Text = "If the langauge you would like to see is not available on the {0} menu, use the l" +
+    "atest Installer to see if it is available to select.";
+			this.m_linkLabelAddDisplayLanguageUsingInstaller.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.HandleLinkClicked);
+			// 
+			// l10NSharpExtender1
+			// 
+			this.l10NSharpExtender1.LocalizationManagerId = null;
+			this.l10NSharpExtender1.PrefixForNewItems = null;
+			// 
+			// MoreUiLanguagesDlg
+			// 
+			this.AcceptButton = this.m_btnOk;
+			this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.AutoSize = true;
+			this.ClientSize = new System.Drawing.Size(668, 174);
+			this.Controls.Add(this.flowLayoutPanel1);
+			this.Controls.Add(this.m_btnOk);
+			this.l10NSharpExtender1.SetLocalizableToolTip(this, null);
+			this.l10NSharpExtender1.SetLocalizationComment(this, null);
+			this.l10NSharpExtender1.SetLocalizingId(this, "MoreUiLanguagesDlg.WindowTitle");
+			this.Name = "MoreUiLanguagesDlg";
+			this.Text = "More Display Languages";
+			this.flowLayoutPanel1.ResumeLayout(false);
+			this.flowLayoutPanel1.PerformLayout();
+			((System.ComponentModel.ISupportInitialize)(this.l10NSharpExtender1)).EndInit();
+			this.ResumeLayout(false);
+			this.PerformLayout();
+
+		}
+
+		#endregion
+
+		private System.Windows.Forms.Button m_btnOk;
+		private System.Windows.Forms.LinkLabel m_linkLabelCrowdinInformation;
+		private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
+		private System.Windows.Forms.LinkLabel m_linkLabelAddDisplayLanguageUsingInstaller;
+		private L10NSharp.UI.L10NSharpExtender l10NSharpExtender1;
+	}
+}

--- a/Transcelerator/MoreUiLanguagesDlg.cs
+++ b/Transcelerator/MoreUiLanguagesDlg.cs
@@ -1,0 +1,72 @@
+﻿// ---------------------------------------------------------------------------------------------
+#region // Copyright (c) 2020, SIL International.   
+// <copyright from='2020' to='2020 company='SIL International'>
+//		Copyright (c) 2020, SIL International.   
+//
+//		Distributable under the terms of the MIT License (http://sil.mit-license.org/)
+// </copyright> 
+#endregion
+// 
+// File: MoreUiLanguagesDlg.cs
+// ---------------------------------------------------------------------------------------------
+using System.Diagnostics;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using L10NSharp;
+using L10NSharp.UI;
+using L10NSharp.XLiffUtils;
+using static System.String;
+
+namespace SIL.Transcelerator
+{
+	public partial class MoreUiLanguagesDlg : Form
+	{
+		private readonly ToolStripItem m_displayLanguageMenu;
+
+		public MoreUiLanguagesDlg(ToolStripItem displayLanguageMenu)
+		{
+			m_displayLanguageMenu = displayLanguageMenu;
+			InitializeComponent();
+			HandleStringsLocalized();
+			LocalizeItemDlg<XLiffDocument>.StringsLocalized += HandleStringsLocalized;
+		}
+
+		private void HandleStringsLocalized()
+		{
+			m_linkLabelAddDisplayLanguageUsingInstaller.Text =
+				Format(m_linkLabelAddDisplayLanguageUsingInstaller.Text,
+					m_displayLanguageMenu.Text.Replace("&", "")) + " ";
+			var startHyperlink = m_linkLabelAddDisplayLanguageUsingInstaller.Text.Length;
+			m_linkLabelAddDisplayLanguageUsingInstaller.Text +=
+				LocalizationManager.GetString("MoreUiLanguagesDlg.Download",
+					"Download the latest Installer.",
+					"Sentence that will be formatted as a hyperlink and appended to " +
+					"\"MoreUiLanguagesDlg.m_linkLabelAddDisplayLanguageUsingInstaller\"");
+			var endHyperlink = m_linkLabelAddDisplayLanguageUsingInstaller.Text.Length;
+			m_linkLabelAddDisplayLanguageUsingInstaller.LinkArea = new LinkArea(startHyperlink, endHyperlink);
+
+			const string kCrowdin = "Crowdin";
+
+			m_linkLabelCrowdinInformation.Text =
+				Format(m_linkLabelCrowdinInformation.Text,
+					TxlPlugin.pluginName, kCrowdin);
+			m_linkLabelCrowdinInformation.LinkArea = new LinkArea(
+				m_linkLabelCrowdinInformation.Text.IndexOf(kCrowdin, StringComparison.Ordinal),
+				kCrowdin.Length);
+		}
+
+		private void HandleLinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+		{
+			var url = ((LinkLabel)sender).Tag as string;
+			if (!IsNullOrEmpty(url))
+				Process.Start(url);
+		}
+	}
+}

--- a/Transcelerator/MoreUiLanguagesDlg.resx
+++ b/Transcelerator/MoreUiLanguagesDlg.resx
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="l10NSharpExtender1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <data name="m_linkLabelCrowdinInformation.Text" xml:space="preserve">
+    <value>{0} uses {1} to manage the localization effort for strings displayed in its user interface and for the source questions to be translated. If you would like to contribute translations or request the addition of another display language, please make your request via {1}.</value>
+  </data>
+</root>

--- a/Transcelerator/Transcelerator.csproj
+++ b/Transcelerator/Transcelerator.csproj
@@ -319,6 +319,12 @@
     <Compile Include="AddRenderingDlg.Designer.cs">
       <DependentUpon>AddRenderingDlg.cs</DependentUpon>
     </Compile>
+    <Compile Include="MoreUiLanguagesDlg.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="MoreUiLanguagesDlg.Designer.cs">
+      <DependentUpon>MoreUiLanguagesDlg.cs</DependentUpon>
+    </Compile>
     <Compile Include="Number.cs" />
     <Compile Include="IProgressMessage.cs" />
     <Compile Include="KeyTerm.cs" />
@@ -437,6 +443,9 @@
     <EmbeddedResource Include="HelpAboutDlg.resx">
       <DependentUpon>HelpAboutDlg.cs</DependentUpon>
       <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="MoreUiLanguagesDlg.resx">
+      <DependentUpon>MoreUiLanguagesDlg.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="NewQuestionDlg.resx">
       <DependentUpon>NewQuestionDlg.cs</DependentUpon>

--- a/Transcelerator/UNSQuestionsDialog.Designer.cs
+++ b/Transcelerator/UNSQuestionsDialog.Designer.cs
@@ -114,6 +114,8 @@ namespace SIL.Transcelerator
 			this.toolStripSeparator9 = new System.Windows.Forms.ToolStripSeparator();
 			this.mnuDisplayLanguage = new System.Windows.Forms.ToolStripMenuItem();
 			this.en_ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripSeparator10 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripMenuItemMoreLanguages = new System.Windows.Forms.ToolStripMenuItem();
 			this.mnuAdvanced = new System.Windows.Forms.ToolStripMenuItem();
 			this.mnuPhraseSubstitutions = new System.Windows.Forms.ToolStripMenuItem();
 			this.mnuBiblicalTermsRenderingSelectionRules = new System.Windows.Forms.ToolStripMenuItem();
@@ -227,7 +229,7 @@ namespace SIL.Transcelerator
 			this.dataGridUns.RowHeadersDefaultCellStyle = dataGridViewCellStyle4;
 			this.dataGridUns.RowHeadersVisible = false;
 			this.dataGridUns.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.CellSelect;
-			this.dataGridUns.Size = new System.Drawing.Size(792, 227);
+			this.dataGridUns.Size = new System.Drawing.Size(792, 203);
 			this.dataGridUns.TabIndex = 7;
 			this.dataGridUns.VirtualMode = true;
 			this.dataGridUns.CellClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridUns_CellClick);
@@ -847,7 +849,9 @@ namespace SIL.Transcelerator
 			// mnuDisplayLanguage
 			// 
 			this.mnuDisplayLanguage.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.en_ToolStripMenuItem});
+            this.en_ToolStripMenuItem,
+            this.toolStripSeparator10,
+            this.toolStripMenuItemMoreLanguages});
 			this.l10NSharpExtender1.SetLocalizableToolTip(this.mnuDisplayLanguage, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this.mnuDisplayLanguage, "To control which character will be the mnemonic key (underlined when the user pre" +
         "sses the ALT key), put the ampersand before the desired character.");
@@ -865,10 +869,25 @@ namespace SIL.Transcelerator
 			this.l10NSharpExtender1.SetLocalizationPriority(this.en_ToolStripMenuItem, L10NSharp.LocalizationPriority.NotLocalizable);
 			this.l10NSharpExtender1.SetLocalizingId(this.en_ToolStripMenuItem, "MainWindow.en_ToolStripMenuItem");
 			this.en_ToolStripMenuItem.Name = "en_ToolStripMenuItem";
-			this.en_ToolStripMenuItem.Size = new System.Drawing.Size(166, 22);
+			this.en_ToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
 			this.en_ToolStripMenuItem.Tag = "en-US";
 			this.en_ToolStripMenuItem.Text = "American English";
 			this.en_ToolStripMenuItem.Click += new System.EventHandler(this.HandleDisplayLanguageSelected);
+			// 
+			// toolStripSeparator10
+			// 
+			this.toolStripSeparator10.Name = "toolStripSeparator10";
+			this.toolStripSeparator10.Size = new System.Drawing.Size(177, 6);
+			// 
+			// toolStripMenuItemMoreLanguages
+			// 
+			this.l10NSharpExtender1.SetLocalizableToolTip(this.toolStripMenuItemMoreLanguages, null);
+			this.l10NSharpExtender1.SetLocalizationComment(this.toolStripMenuItemMoreLanguages, null);
+			this.l10NSharpExtender1.SetLocalizingId(this.toolStripMenuItemMoreLanguages, "MainWindow.UNSQuestionsDialog.toolStripMenuItem1");
+			this.toolStripMenuItemMoreLanguages.Name = "toolStripMenuItemMoreLanguages";
+			this.toolStripMenuItemMoreLanguages.Size = new System.Drawing.Size(180, 22);
+			this.toolStripMenuItemMoreLanguages.Text = "&More...";
+			this.toolStripMenuItemMoreLanguages.Click += new System.EventHandler(this.toolStripMenuItemMoreLanguages_Click);
 			// 
 			// mnuAdvanced
 			// 
@@ -986,7 +1005,7 @@ namespace SIL.Transcelerator
 			this.l10NSharpExtender1.SetLocalizationComment(this.txtFilterByPart, null);
 			this.l10NSharpExtender1.SetLocalizingId(this.txtFilterByPart, "MainWindow.txtFilterByPart");
 			this.txtFilterByPart.Name = "txtFilterByPart";
-			this.txtFilterByPart.Size = new System.Drawing.Size(200, 25);
+			this.txtFilterByPart.Size = new System.Drawing.Size(240, 25);
 			this.txtFilterByPart.ToolTipText = "Type an English word or phrase to filter the list of questions.";
 			this.txtFilterByPart.Enter += new System.EventHandler(this.txtFilterByPart_Enter);
 			this.txtFilterByPart.Leave += new System.EventHandler(this.txtFilterByPart_Leave);
@@ -1058,12 +1077,12 @@ namespace SIL.Transcelerator
 			this.m_biblicalTermsPane.ColumnCount = 1;
 			this.m_biblicalTermsPane.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
 			this.m_biblicalTermsPane.Dock = System.Windows.Forms.DockStyle.Bottom;
-			this.m_biblicalTermsPane.Location = new System.Drawing.Point(3, 282);
+			this.m_biblicalTermsPane.Location = new System.Drawing.Point(3, 258);
 			this.m_biblicalTermsPane.MinimumSize = new System.Drawing.Size(100, 40);
 			this.m_biblicalTermsPane.Name = "m_biblicalTermsPane";
 			this.m_biblicalTermsPane.RowCount = 1;
 			this.m_biblicalTermsPane.RowStyles.Add(new System.Windows.Forms.RowStyle());
-			this.m_biblicalTermsPane.Size = new System.Drawing.Size(792, 117);
+			this.m_biblicalTermsPane.Size = new System.Drawing.Size(792, 135);
 			this.m_biblicalTermsPane.TabIndex = 17;
 			this.m_biblicalTermsPane.Resize += new System.EventHandler(this.m_biblicalTermsPane_Resize);
 			// 
@@ -1076,7 +1095,7 @@ namespace SIL.Transcelerator
 			this.m_lblAnswerLabel.Location = new System.Drawing.Point(3, 0);
 			this.m_lblAnswerLabel.Name = "m_lblAnswerLabel";
 			this.m_lblAnswerLabel.Padding = new System.Windows.Forms.Padding(1, 3, 1, 3);
-			this.m_lblAnswerLabel.Size = new System.Drawing.Size(67, 19);
+			this.m_lblAnswerLabel.Size = new System.Drawing.Size(80, 22);
 			this.m_lblAnswerLabel.TabIndex = 0;
 			this.m_lblAnswerLabel.Text = "Answer:";
 			// 
@@ -1088,10 +1107,10 @@ namespace SIL.Transcelerator
 			this.l10NSharpExtender1.SetLocalizationComment(this.m_lblAnswers, null);
 			this.l10NSharpExtender1.SetLocalizationPriority(this.m_lblAnswers, L10NSharp.LocalizationPriority.NotLocalizable);
 			this.l10NSharpExtender1.SetLocalizingId(this.m_lblAnswers, "MainWindow.m_lblAnswers");
-			this.m_lblAnswers.Location = new System.Drawing.Point(76, 0);
+			this.m_lblAnswers.Location = new System.Drawing.Point(89, 0);
 			this.m_lblAnswers.Name = "m_lblAnswers";
 			this.m_lblAnswers.Padding = new System.Windows.Forms.Padding(0, 3, 0, 3);
-			this.m_lblAnswers.Size = new System.Drawing.Size(14, 19);
+			this.m_lblAnswers.Size = new System.Drawing.Size(15, 22);
 			this.m_lblAnswers.TabIndex = 2;
 			this.m_lblAnswers.Text = "#";
 			// 
@@ -1101,10 +1120,10 @@ namespace SIL.Transcelerator
 			this.l10NSharpExtender1.SetLocalizableToolTip(this.m_lblCommentLabel, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this.m_lblCommentLabel, null);
 			this.l10NSharpExtender1.SetLocalizingId(this.m_lblCommentLabel, "MainWindow.m_lblCommentLabel");
-			this.m_lblCommentLabel.Location = new System.Drawing.Point(3, 19);
+			this.m_lblCommentLabel.Location = new System.Drawing.Point(3, 22);
 			this.m_lblCommentLabel.Name = "m_lblCommentLabel";
 			this.m_lblCommentLabel.Padding = new System.Windows.Forms.Padding(1, 3, 1, 3);
-			this.m_lblCommentLabel.Size = new System.Drawing.Size(67, 19);
+			this.m_lblCommentLabel.Size = new System.Drawing.Size(80, 22);
 			this.m_lblCommentLabel.TabIndex = 1;
 			this.m_lblCommentLabel.Text = "Comment:";
 			// 
@@ -1116,10 +1135,10 @@ namespace SIL.Transcelerator
 			this.l10NSharpExtender1.SetLocalizationComment(this.m_lblComments, null);
 			this.l10NSharpExtender1.SetLocalizationPriority(this.m_lblComments, L10NSharp.LocalizationPriority.NotLocalizable);
 			this.l10NSharpExtender1.SetLocalizingId(this.m_lblComments, "MainWindow.m_lblComments");
-			this.m_lblComments.Location = new System.Drawing.Point(76, 19);
+			this.m_lblComments.Location = new System.Drawing.Point(89, 22);
 			this.m_lblComments.Name = "m_lblComments";
 			this.m_lblComments.Padding = new System.Windows.Forms.Padding(0, 3, 0, 3);
-			this.m_lblComments.Size = new System.Drawing.Size(14, 19);
+			this.m_lblComments.Size = new System.Drawing.Size(15, 22);
 			this.m_lblComments.TabIndex = 3;
 			this.m_lblComments.Text = "#";
 			// 
@@ -1135,12 +1154,12 @@ namespace SIL.Transcelerator
 			this.m_pnlAnswersAndComments.Controls.Add(this.m_lblAnswerLabel, 0, 0);
 			this.m_pnlAnswersAndComments.Controls.Add(this.m_lblCommentLabel, 0, 1);
 			this.m_pnlAnswersAndComments.Dock = System.Windows.Forms.DockStyle.Bottom;
-			this.m_pnlAnswersAndComments.Location = new System.Drawing.Point(3, 399);
+			this.m_pnlAnswersAndComments.Location = new System.Drawing.Point(3, 393);
 			this.m_pnlAnswersAndComments.Name = "m_pnlAnswersAndComments";
 			this.m_pnlAnswersAndComments.RowCount = 2;
 			this.m_pnlAnswersAndComments.RowStyles.Add(new System.Windows.Forms.RowStyle());
 			this.m_pnlAnswersAndComments.RowStyles.Add(new System.Windows.Forms.RowStyle());
-			this.m_pnlAnswersAndComments.Size = new System.Drawing.Size(792, 38);
+			this.m_pnlAnswersAndComments.Size = new System.Drawing.Size(792, 44);
 			this.m_pnlAnswersAndComments.TabIndex = 19;
 			this.m_pnlAnswersAndComments.Visible = false;
 			this.m_pnlAnswersAndComments.VisibleChanged += new System.EventHandler(this.LoadAnswersAndCommentsIfShowing);
@@ -1149,7 +1168,7 @@ namespace SIL.Transcelerator
 			// 
 			this.m_hSplitter.Cursor = System.Windows.Forms.Cursors.HSplit;
 			this.m_hSplitter.Dock = System.Windows.Forms.DockStyle.Bottom;
-			this.m_hSplitter.Location = new System.Drawing.Point(3, 279);
+			this.m_hSplitter.Location = new System.Drawing.Point(3, 255);
 			this.m_hSplitter.Name = "m_hSplitter";
 			this.m_hSplitter.Size = new System.Drawing.Size(792, 3);
 			this.m_hSplitter.TabIndex = 20;
@@ -1164,7 +1183,7 @@ namespace SIL.Transcelerator
 			// UNSQuestionsDialog
 			// 
 			this.AccessibleName = "Transcelerator Main Window";
-			this.AutoScaleBaseSize = new System.Drawing.Size(5, 13);
+			this.AutoScaleBaseSize = new System.Drawing.Size(6, 15);
 			this.ClientSize = new System.Drawing.Size(798, 440);
 			this.Controls.Add(this.dataGridUns);
 			this.Controls.Add(this.m_hSplitter);
@@ -1179,7 +1198,7 @@ namespace SIL.Transcelerator
 			this.l10NSharpExtender1.SetLocalizationPriority(this, L10NSharp.LocalizationPriority.NotLocalizable);
 			this.l10NSharpExtender1.SetLocalizingId(this, "MainWindow.WindowTitle");
 			this.MainMenuStrip = this.m_mainMenu;
-			this.MinimumSize = new System.Drawing.Size(180, 150);
+			this.MinimumSize = new System.Drawing.Size(216, 173);
 			this.Name = "UNSQuestionsDialog";
 			this.Padding = new System.Windows.Forms.Padding(3);
 			this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
@@ -1280,5 +1299,7 @@ namespace SIL.Transcelerator
 		private DataGridViewCheckBoxColumn m_colUserTranslated;
 		private DataGridViewTextBoxColumn m_colDebugInfo;
 		private ToolStripMenuItem mnuViewDebugInfo;
+		private ToolStripSeparator toolStripSeparator10;
+		private ToolStripMenuItem toolStripMenuItemMoreLanguages;
 	}
 }

--- a/Transcelerator/UNSQuestionsDialog.cs
+++ b/Transcelerator/UNSQuestionsDialog.cs
@@ -367,12 +367,13 @@ namespace SIL.Transcelerator
 			if (!IsNullOrEmpty(Properties.Settings.Default.OverrideDisplayLanguage))
 			{
 				preferredUiLocale = Properties.Settings.Default.OverrideDisplayLanguage;
-				if (preferredUiLocale.Length > 2 && LocalizationManager.UILanguageId.Length >= 2 &&
+				if (preferredUiLocale.Length >= 2 && LocalizationManager.UILanguageId.Length >= 2 &&
 					preferredUiLocale.Substring(0, 2) != LocalizationManager.UILanguageId.Substring(0, 2))
 				{
-					// Unless/until we ship different variants of the same language, there is no need
-					// to try to tell the localization manager to load a different variant. It's already
-					// smart enough to fallback to another variant of the language anyway.
+					// Unless/until we ship UI strings for different variants of the same language,
+					// there is no need to try to tell the LocalizationManager to load a different
+					// variant. It's already smart enough to fallback to another variant of the
+					// language anyway.
 					LocalizationManager.SetUILanguage(preferredUiLocale, true);
 				}
 			}

--- a/Transcelerator/UNSQuestionsDialog.cs
+++ b/Transcelerator/UNSQuestionsDialog.cs
@@ -496,6 +496,7 @@ namespace SIL.Transcelerator
 		private void AddAvailableLocalizationsToMenu(string preferredLocale)
 		{
 			var menuItemNameSuffix = en_ToolStripMenuItem.Name.Substring(2);
+			int insertAt = mnuDisplayLanguage.DropDownItems.IndexOf(en_ToolStripMenuItem) + 1;
 			foreach (var availableLocalization in AvailableLocales)
 			{
 				var subItem = new ToolStripMenuItem(availableLocalization.Key)
@@ -503,7 +504,7 @@ namespace SIL.Transcelerator
 					Tag = availableLocalization.Value,
 					Name = availableLocalization.Value + menuItemNameSuffix
 				};
-				mnuDisplayLanguage.DropDownItems.Add(subItem);
+				mnuDisplayLanguage.DropDownItems.Insert(insertAt++, subItem);
 				if (availableLocalization.Value == preferredLocale)
 				{
 					en_ToolStripMenuItem.Checked = false;
@@ -2373,7 +2374,7 @@ namespace SIL.Transcelerator
 			if (clickedMenu.Checked)
 				return;
 			clickedMenu.Checked = true;
-			foreach (ToolStripMenuItem subMenu in mnuDisplayLanguage.DropDownItems)
+			foreach (var subMenu in mnuDisplayLanguage.DropDownItems.OfType<ToolStripMenuItem>().Where(i => i.Tag != null))
 			{
 				if (subMenu != clickedMenu)
 					subMenu.Checked = false;
@@ -2387,6 +2388,14 @@ namespace SIL.Transcelerator
 				dataGridUns.Invalidate();
 			LoadAnswersAndCommentsIfShowing(null, null);
 			LocalizationManager.SetUILanguage(localeId, true);
+		}
+		
+		private void toolStripMenuItemMoreLanguages_Click(object sender, EventArgs e)
+		{
+			using (var dlg = new MoreUiLanguagesDlg(mnuDisplayLanguage))
+			{
+				dlg.ShowDialog(this);
+			}
 		}
 #endregion
 
@@ -3015,6 +3024,7 @@ namespace SIL.Transcelerator
 			}
 		}
 		#endregion
+
 	}
 	#endregion
 

--- a/l10n/l10n.proj
+++ b/l10n/l10n.proj
@@ -17,7 +17,7 @@
 		2) If dynamic strings or other localizable strings that cannot be detected
 		by ExtractXliff are ever needed, create and check in a Transcelerator.en.xlf file
 		with them, and add this parameter: -b ..\DistFiles\localization\Transcelerator.en.xlf -->
-	<Exec Command="&quot;$(PkgL10NSharp_ExtractXliff)\tools\ExtractXliff.exe&quot; -n SIL.Transcelerator -o Transcelerator.dll -x Transcelerator.en.xlf -p 1.5.0 ../output/$(Configuration)/Transcelerator.dll" />
+	<Exec Command="&quot;$(PkgL10NSharp_ExtractXliff)\tools\ExtractXliff.exe&quot; -n SIL.Transcelerator -o Transcelerator.dll -x Transcelerator.en.xlf -p 1.5.4 ../output/$(Configuration)/Transcelerator.dll" />
 	<!-- <Exec Command="overcrowdin updatefiles" /> -->
   </Target>
 </Project>


### PR DESCRIPTION
for each version of Paratext where Transcelerator is installed, even if no localizations are selected.

Added erroneously omitted French localizations
Updated Spanish localizations from Crowdin
Added "More" option to Display Languages submenu to display informational dialog

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/transcelerator/29)
<!-- Reviewable:end -->
