### PR TITLE
Prevent "; or," in gloss from creating "Or" as a key term

### DIFF
--- a/Transcelerator/KeyTermMatchBuilder.cs
+++ b/Transcelerator/KeyTermMatchBuilder.cs
@@ -44,7 +44,7 @@ namespace SIL.Transcelerator
 	    /// </summary>
 	    /// <param name="keyTerm">The key term.</param>
 	    /// <param name="rules">Optional dictionary of (English) key terms to rules indicating
-	    /// special handling neeeded.</param>
+	    /// special handling needed.</param>
         /// <param name="regexRules">regular-expression-based rules. If any term matches a
 	    /// regular expression in this collection, terms will be extracted using the variable
 	    /// "term". If the term variable is not present in the regular expression, this term
@@ -54,9 +54,8 @@ namespace SIL.Transcelerator
             IEnumerable<Regex> regexRules)
 		{
 			string normalizedLcTerm = keyTerm.Term.ToLowerInvariant().Normalize(NormalizationForm.FormC);
-			KeyTermRule ktRule;
-            bool fMatchForRefOnly = false;
-            if (rules != null && rules.TryGetValue(normalizedLcTerm, out ktRule))
+			bool fMatchForRefOnly = false;
+            if (rules != null && rules.TryGetValue(normalizedLcTerm, out var ktRule))
 			{
                 ktRule.Used = true;
 				bool fExcludeMainTerm = false;
@@ -94,7 +93,7 @@ namespace SIL.Transcelerator
                         return;
                 }
             }
-            foreach (string phrase in normalizedLcTerm.Split(new[] { ", or ", ",", ";", "=" }, StringSplitOptions.RemoveEmptyEntries))
+            foreach (string phrase in normalizedLcTerm.Split(new[] { "; or, ", ", or ", ",", ";", "=" }, StringSplitOptions.RemoveEmptyEntries))
 				ProcessKeyTermPhrase(keyTerm, phrase, fMatchForRefOnly);
 		}
 

--- a/Transcelerator/TransceleratorTests/KeyTermMatchBuilderTests.cs
+++ b/Transcelerator/TransceleratorTests/KeyTermMatchBuilderTests.cs
@@ -685,6 +685,21 @@ namespace SIL.Transcelerator
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
 		/// Tests the KeyTermMatchBuilder class in the case of a key term from the world of
+		/// real evil data.
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		[Test]
+		public void RealData16()
+		{
+			KeyTermMatchBuilder bldr = new KeyTermMatchBuilder(AddMockedKeyTerm("laurustinus; or, pine tree"));
+			Assert.AreEqual(2, bldr.Matches.Count());
+			VerifyKeyTermMatch(bldr, 0, "laurustinus");
+			VerifyKeyTermMatch(bldr, 1, "pine", "tree");
+		}
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Tests the KeyTermMatchBuilder class in the case of a key term from the world of
 		/// real evil data: "or" separating two words
 		/// </summary>
 		/// ------------------------------------------------------------------------------------


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/transcelerator/33)
<!-- Reviewable:end -->
