### PR TITLE
TXL-227: Prevent weird custom questions from causing crash

### DIFF
--- a/Transcelerator/MasterQuestionParser.cs
+++ b/Transcelerator/MasterQuestionParser.cs
@@ -619,8 +619,15 @@ namespace SIL.Transcelerator
 		        return true;
 	        }
 
+			// In theory questions cannot be added that span multiple sections, but it used to
+			// be possible (and may become possible again in the future?). In any case, if we
+			// find a question that does, we want to keep it with the section that contains the
+			// base question rather than having it get left to be processed totally out of order
+			// in GetTrailingCustomizations. Therefore, rather than strictly checking that the
+			// custom question is wholly contained in the sectionRange (using &&), we just make
+			// sure it at least partially pertains to the sectionRange (using ||).
 	        foreach (var kvpCustomization in customizations
-		        .TakeWhile(c => c.Key.EndRef <= sectionRange.EndRef && c.Key.StartRef >= sectionRange.StartRef)
+		        .TakeWhile(c => c.Key.EndRef <= sectionRange.EndRef || c.Key.StartRef >= sectionRange.StartRef)
 		        .Where(c => c.Value.IsAdditionOfDifferentPhrase)) // If user just changed the reference, it gets dealt with elsewhere.
 			{
 				if (kvpCustomization.Key.Text == question.PhraseInUse)

--- a/Transcelerator/UNSQuestionsDialog.cs
+++ b/Transcelerator/UNSQuestionsDialog.cs
@@ -2516,7 +2516,7 @@ namespace SIL.Transcelerator
 					MessageBox.Show(e.ToString());
 				else
 				{
-					foreach (XmlTranslation unsTranslation in translations)
+					foreach (XmlTranslation unsTranslation in translations.Where(t => !IsNullOrWhiteSpace(t.Translation)))
 					{
 						TranslatablePhrase phrase = m_helper.GetPhrase(unsTranslation.Reference, unsTranslation.PhraseKey);
 						if (phrase != null && !phrase.IsExcluded)


### PR DESCRIPTION
Prevent custom questions whose reference range spans sections from being stuck at the end of the book, leading to subsequent crash when generating the script.
Also, when loading omit translations that consist only of whitespace (however that might have happened).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/transcelerator/37)
<!-- Reviewable:end -->
