### PR TITLE
TXL-233 If no questions in a book have user translations, clear existing translations in SF output files

### DIFF
--- a/Transcelerator/DataFileAccessor.cs
+++ b/Transcelerator/DataFileAccessor.cs
@@ -89,6 +89,8 @@ namespace SIL.Transcelerator
 			WriteBookSpecificData(fileId, bookId, serializedData);
 		}
 
+		public abstract bool BookSpecificDataExists(BookSpecificDataFileId fileId, string bookId);
+
 		protected abstract void WriteBookSpecificData(BookSpecificDataFileId fileId, string bookId, string data);
 
 		public abstract string Read(DataFileId fileId);
@@ -155,6 +157,11 @@ namespace SIL.Transcelerator
         {
             return m_getPlugInDataModifiedTime(GetFileName(fileId)).Ticks > 0;
         }
+
+		public override bool BookSpecificDataExists(BookSpecificDataFileId fileId, string bookId)
+		{
+			return m_getPlugInDataModifiedTime(GetBookSpecificFileName(fileId, bookId)).Ticks > 0;
+		}
 
         public override DateTime ModifiedTime(DataFileId fileId)
         {

--- a/Transcelerator/PhraseTranslationHelper.cs
+++ b/Transcelerator/PhraseTranslationHelper.cs
@@ -380,6 +380,8 @@ namespace SIL.Transcelerator
 						};
 						AdvanceEnumerator();
 					}
+					if (e != null && currBook == e.Current)
+						AdvanceEnumerator();
 					
 					currentBookQuestions = new ComprehensionCheckingQuestionsForBook
 					{

--- a/Transcelerator/TransceleratorTests/KeyTermTests.cs
+++ b/Transcelerator/TransceleratorTests/KeyTermTests.cs
@@ -199,6 +199,11 @@ namespace SIL.Transcelerator
             Data = data;
         }
 
+		public override bool BookSpecificDataExists(BookSpecificDataFileId fileId, string bookId)
+		{
+			throw new NotImplementedException();
+		}
+
 		protected override void WriteBookSpecificData(BookSpecificDataFileId fileId, string bookId, string data)
 	    {
 		    throw new NotImplementedException();

--- a/Transcelerator/TransceleratorTests/PhraseTranslationHelperTests.cs
+++ b/Transcelerator/TransceleratorTests/PhraseTranslationHelperTests.cs
@@ -4304,8 +4304,11 @@ namespace SIL.Transcelerator
 		}
 		
         // TXL-233
-		[Test]
-		public void GetQuestionsForBooks_TwoBooksPlusThreeThatNoLongerHaveUserConfirmedTranslations_BooksWithoutTranslationsReturnEmptyList()
+		[TestCase(2, 44, 66)]
+		[TestCase(2, 40, 44, 66)]
+		[TestCase(2, 40, 44, 65, 66)]
+		public void GetQuestionsForBooks_TwoBooksIncludingSomeThatNoLongerHaveUserConfirmedTranslations_BooksWithoutTranslationsReturnEmptyList(
+			params int[] existing)
 		{
 			var vernLocale = "en-US";
 			var frenchLocalizations = MockRepository.GenerateMock<ILocalizationsProvider>();
@@ -4337,7 +4340,7 @@ namespace SIL.Transcelerator
 			pth.GetPhrase("MAT 2:2", "Q2").Translation = $"{vernLocale} What was her name?";
 			pth.GetPhrase("JUD 1:4-5", "Q3").Translation = $"{vernLocale} Who ate the pizza?";
 
-			var result = pth.GetQuestionsForBooks(vernLocale, new [] {spanishLocalizations, frenchLocalizations}, new int[] {2, 44, 66}).ToList();
+			var result = pth.GetQuestionsForBooks(vernLocale, new [] {spanishLocalizations, frenchLocalizations}, existing).ToList();
             Assert.AreEqual(5, result.Count);
 
 			int i = 0;

--- a/Transcelerator/TransceleratorTests/PhraseTranslationHelperTests.cs
+++ b/Transcelerator/TransceleratorTests/PhraseTranslationHelperTests.cs
@@ -4277,7 +4277,7 @@ namespace SIL.Transcelerator
 			pth.GetPhrase("MAT 2:2", "Q2").Translation = $"{vernLocale} What was her name?";
 			pth.GetPhrase("REV 6:4-5", "Q3").Translation = $"{vernLocale} Who ate the pizza?";
 
-			var result = pth.GetQuestionsForBooks(vernLocale, new [] {spanishLocalizations, frenchLocalizations}).ToList();
+			var result = pth.GetQuestionsForBooks(vernLocale, new [] {spanishLocalizations, frenchLocalizations}, new int[0]).ToList();
             Assert.AreEqual(2, result.Count);
 
             // Verify MAT questions
@@ -4301,6 +4301,82 @@ namespace SIL.Transcelerator
             Assert.AreEqual("Q3", q3.Id);
             Assert.AreEqual($"{vernLocale} Who ate the pizza?", q3.Question.Single(q => q.Lang == vernLocale).Text);
             Assert.AreEqual(vernLocale == "oth" ? 4 : 3, rev.Questions.Single().Question.Length);
+		}
+		
+        // TXL-233
+		[Test]
+		public void GetQuestionsForBooks_TwoBooksPlusThreeThatNoLongerHaveUserConfirmedTranslations_BooksWithoutTranslationsReturnEmptyList()
+		{
+			var vernLocale = "en-US";
+			var frenchLocalizations = MockRepository.GenerateMock<ILocalizationsProvider>();
+			frenchLocalizations.Stub(l => l.Locale).Return("fr");
+			frenchLocalizations.Stub(l => l.TryGetLocalizedString(Arg<UIDataString>.Matches(d => d.Question == "Q1"),
+				out Arg<string>.Out("frQ1").Dummy)).Return(true);
+			frenchLocalizations.Stub(l => l.TryGetLocalizedString(Arg<UIDataString>.Matches(d => d.Question == "Q2"),
+				out Arg<string>.Out("frQ2").Dummy)).Return(true);
+			frenchLocalizations.Stub(l => l.TryGetLocalizedString(Arg<UIDataString>.Matches(d => d.Question == "Q3"),
+				out Arg<string>.Out("frQ3").Dummy)).Return(true);
+            
+			var spanishLocalizations = MockRepository.GenerateMock<ILocalizationsProvider>();
+			spanishLocalizations.Stub(l => l.Locale).Return("es");
+			spanishLocalizations.Stub(l => l.TryGetLocalizedString(Arg<UIDataString>.Matches(d => d.Question == "Q1"),
+				out Arg<string>.Out("esQ1").Dummy)).Return(true);
+			spanishLocalizations.Stub(l => l.TryGetLocalizedString(Arg<UIDataString>.Matches(d => d.Question == "Q2"),
+				out Arg<string>.Out("esQ2").Dummy)).Return(true);
+			spanishLocalizations.Stub(l => l.TryGetLocalizedString(Arg<UIDataString>.Matches(d => d.Question == "Q3"),
+				out Arg<string>.Out("esQ3").Dummy)).Return(true);
+
+			var cat = m_sections.Items[0].Categories[0];
+			AddTestQuestion(cat, "Q1", "MAT 2.2", 40002002, 40002002, "Q1");
+			AddTestQuestion(cat, "Q2", "MAT 2.2", 40002002, 40002002, "Q2");
+			AddTestQuestion(cat, "Q3", "JUD 1.4-5", 65001004, 65001005, "Q2");
+
+			var qp = new QuestionProvider(GetParsedQuestions());
+			PhraseTranslationHelper pth = new PhraseTranslationHelper(qp);
+			pth.GetPhrase("MAT 2:2", "Q1").Translation = $"{vernLocale} Why so many frogs?";
+			pth.GetPhrase("MAT 2:2", "Q2").Translation = $"{vernLocale} What was her name?";
+			pth.GetPhrase("JUD 1:4-5", "Q3").Translation = $"{vernLocale} Who ate the pizza?";
+
+			var result = pth.GetQuestionsForBooks(vernLocale, new [] {spanishLocalizations, frenchLocalizations}, new int[] {2, 44, 66}).ToList();
+            Assert.AreEqual(5, result.Count);
+
+			int i = 0;
+			// Verify EXO questions
+			var r = result[i];
+			Assert.AreEqual("EXO", r.BookId);
+			Assert.AreEqual(0, r.Questions.Count);
+
+            // Verify MAT questions
+			r = result[++i];
+            Assert.AreEqual("MAT", r.BookId);
+            Assert.AreEqual(2, r.Questions.Count);
+			var q1 = r.Questions[0];
+            Assert.AreEqual("Q1", q1.Id);
+            Assert.AreEqual($"{vernLocale} Why so many frogs?", q1.Question.Single(q => q.Lang == vernLocale).Text);
+			var q2 = r.Questions[1];
+            Assert.AreEqual("Q2", q2.Id);
+			pth.GetPhrase("MAT 2:2", "Q2").ModifiedPhrase = "This should not be the ID";
+			Assert.AreEqual("Q2", q2.Id);
+            Assert.AreEqual($"{vernLocale} What was her name?", q2.Question.Single(q => q.Lang == vernLocale).Text);
+			Assert.IsTrue(r.Questions.All(q => q.Question.Length == (vernLocale == "oth" ? 4 : 3)));
+            
+			// Verify ACT questions
+			r = result[++i];
+			Assert.AreEqual("ACT", r.BookId);
+			Assert.AreEqual(0, r.Questions.Count);
+
+			// Verify JUD questions
+			r = result[++i];
+			Assert.AreEqual("JUD", r.BookId);
+			var q3 = r.Questions[0];
+			Assert.AreEqual("Q3", q3.Id);
+			Assert.AreEqual($"{vernLocale} Who ate the pizza?", q3.Question.Single(q => q.Lang == vernLocale).Text);
+			Assert.AreEqual(vernLocale == "oth" ? 4 : 3, r.Questions.Single().Question.Length);
+
+            // Verify REV questions
+			r = result[++i];
+			Assert.AreEqual("REV", r.BookId);
+			Assert.AreEqual(0, r.Questions.Count);
 		}
 
 		#region Private helper methods

--- a/Transcelerator/UNSQuestionsDialog.cs
+++ b/Transcelerator/UNSQuestionsDialog.cs
@@ -1514,7 +1514,19 @@ namespace SIL.Transcelerator
 			{
 				var allAvailableLocalizers = LocalizationsFileAccessor.GetAvailableLocales(m_installDir).Select(GetDataLocalizer).ToList();
 
-				foreach (var questionsForBook in m_helper.GetQuestionsForBooks(m_vernIcuLocale, allAvailableLocalizers))
+				// TXL-233: If Scripture Forge output files are created for a book but the user
+				// later goes back and removes user-confirmed translations such that the book has
+				// none, GetQuestionsForBooks needs to include those books with an empty list so
+				// that the existing files are not left with the old content.
+				var booksWithExistingSfFiles = new List<int>();
+				for (var b = 1; b <= BCVRef.LastBook; b++)
+				{
+					var bookId = BCVRef.NumberToBookCode(b);
+					if (m_fileAccessor.BookSpecificDataExists(DataFileAccessor.BookSpecificDataFileId.ScriptureForge, bookId))
+						booksWithExistingSfFiles.Add(b);
+				}
+
+				foreach (var questionsForBook in m_helper.GetQuestionsForBooks(m_vernIcuLocale, allAvailableLocalizers, booksWithExistingSfFiles))
 				{
 					m_fileAccessor.WriteBookSpecificData(DataFileAccessor.BookSpecificDataFileId.ScriptureForge,
 						questionsForBook.BookId, questionsForBook);


### PR DESCRIPTION
This change was originally (incorrectly) made in a PR against the 64-bit branch. Here the commits are cherry-picked to be merged into master (which is still building 32-bit).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/transcelerator/60)
<!-- Reviewable:end -->
