### PR TITLE
TXL-237: Fixed crash caused by increasing start ref to be greater than the end ref.

### DIFF
--- a/Transcelerator/NewQuestionDlg.cs
+++ b/Transcelerator/NewQuestionDlg.cs
@@ -1,7 +1,7 @@
 // ---------------------------------------------------------------------------------------------
-#region // Copyright (c) 2020, SIL International.
-// <copyright from='2012' to='2020' company='SIL International'>
-//		Copyright (c) 2020, SIL International.
+#region // Copyright (c) 2021, SIL International.
+// <copyright from='2012' to='2021' company='SIL International'>
+//		Copyright (c) 2021, SIL International.
 //
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)
 // </copyright>
@@ -20,6 +20,7 @@ using L10NSharp.UI;
 using L10NSharp.XLiffUtils;
 using SIL.ObjectModel;
 using SIL.Scripture;
+using static System.Int32;
 using static System.String;
 
 namespace SIL.Transcelerator
@@ -383,6 +384,15 @@ namespace SIL.Transcelerator
 					newRefInMasterVersification < m_currentSections[0].Value.StartRef ||
 					newRefInMasterVersification > m_currentSections.Last().Value.EndRef;
 
+				// If the start verse is set beyond the end verse, we get into a funny state where the
+				// arithmetically calculated end verse can come back greater than the last verse in the chapter
+				// because we have not yet repopulated the end verse combo box but the calculation of EdnVerse
+				// (which will be used in SetCurrentSelections) doesn't know that. Unfortunately, we have a
+				// chicken-and-egg problem because we need to have the current sections to repopulate it, so
+				// we just remove items we know are impossible now to ensure that the EndVerse is valid.
+				while (m_cboEndVerse.Items.Count > 1 && Parse((string)m_cboEndVerse.Items[1]) < StartVerse)
+					m_cboEndVerse.Items.RemoveAt(1);
+				
 				SetCurrentSections();
 				PopulateEndRefComboBox();
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/transcelerator/72)
<!-- Reviewable:end -->
