### PR TITLE
Fixed key term rule

### DIFF
--- a/Transcelerator/keyTermRules.xml
+++ b/Transcelerator/keyTermRules.xml
@@ -767,8 +767,9 @@
   </KeyTermRule>
 
   <!-- New Terms in P8 -->
-  <KeyTermRule id ="female fallow deer, doe">
-    <Alternate name="doe"/>
+  <KeyTermRule id ="female fallow deer, doe" rule="Exclude">
+    <Alternate name="deer"/>
+    <Alternate name="doe" matchForRefOnly="true"/>
     <Alternate name="does" matchForRefOnly="true"/>
   </KeyTermRule>
 </KeyTermRules>


### PR DESCRIPTION
 This prevents "does" from being processed as the plural of "doe." Also added useful match for "deer".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/transcelerator/78)
<!-- Reviewable:end -->
