### PR TITLE
Fixed layout problem in Answers/Comments panel

### DIFF
--- a/Transcelerator/UNSQuestionsDialog.Designer.cs
+++ b/Transcelerator/UNSQuestionsDialog.Designer.cs
@@ -1091,6 +1091,7 @@ namespace SIL.Transcelerator
 			// 
 			// m_lblAnswerLabel
 			// 
+			this.m_lblAnswerLabel.AutoSize = true;
 			this.m_lblAnswerLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold);
 			this.l10NSharpExtender1.SetLocalizableToolTip(this.m_lblAnswerLabel, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this.m_lblAnswerLabel, null);
@@ -1119,6 +1120,7 @@ namespace SIL.Transcelerator
 			// 
 			// m_lblCommentLabel
 			// 
+			this.m_lblCommentLabel.AutoSize = true;
 			this.m_lblCommentLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold);
 			this.l10NSharpExtender1.SetLocalizableToolTip(this.m_lblCommentLabel, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this.m_lblCommentLabel, null);


### PR DESCRIPTION
Labels needed to be auto-sized to lay out correctly when showing UI strings in a language besides English.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/transcelerator/100)
<!-- Reviewable:end -->
