### PR TITLE
Fixed build config anomalies

### DIFF
--- a/ComprehensionCheckingData/ComprehensionCheckingData.csproj
+++ b/ComprehensionCheckingData/ComprehensionCheckingData.csproj
@@ -3,7 +3,7 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
     <ProjectGuid>{C6474F83-4E0A-462F-BD87-883C197F1BE6}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>

--- a/DataIntegrityTests/DataIntegrityTests.csproj
+++ b/DataIntegrityTests/DataIntegrityTests.csproj
@@ -3,7 +3,7 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
     <ProjectGuid>{E71615C2-2056-491D-AC85-FFEB0FC9D34A}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>

--- a/SilUtils/SilUtils.csproj
+++ b/SilUtils/SilUtils.csproj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="14.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
     <ProductVersion>9.0.30729</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{4E4CE84F-BB35-416A-8E4F-B8C096DA32B7}</ProjectGuid>

--- a/SilUtils/SilUtilsTests/SilUtilsTests.csproj
+++ b/SilUtils/SilUtilsTests/SilUtilsTests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\packages\NUnit.3.13.3\build\NUnit.props" Condition="Exists('..\..\packages\NUnit.3.13.3\build\NUnit.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
     <ProductVersion>9.0.30729</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{F023F83B-EC39-48D4-A98C-F65E43609B20}</ProjectGuid>

--- a/Transcelerator.sln
+++ b/Transcelerator.sln
@@ -115,7 +115,8 @@ Global
 		{4E4CE84F-BB35-416A-8E4F-B8C096DA32B7}.Release|Any CPU.Build.0 = Release|Any CPU
 		{4E4CE84F-BB35-416A-8E4F-B8C096DA32B7}.Release|x64.ActiveCfg = Release|x64
 		{4E4CE84F-BB35-416A-8E4F-B8C096DA32B7}.Release|x64.Build.0 = Release|x64
-		{54363E9B-3A5A-46D6-9ACA-3F1626572647}.Debug - Copy To Paratext|Any CPU.ActiveCfg = Debug - Copy To Paratext|x86
+		{54363E9B-3A5A-46D6-9ACA-3F1626572647}.Debug - Copy To Paratext|Any CPU.ActiveCfg = Debug - Copy To Paratext|Any CPU
+		{54363E9B-3A5A-46D6-9ACA-3F1626572647}.Debug - Copy To Paratext|Any CPU.Build.0 = Debug - Copy To Paratext|Any CPU
 		{54363E9B-3A5A-46D6-9ACA-3F1626572647}.Debug - Copy To Paratext|x64.ActiveCfg = Debug - Copy To Paratext|x64
 		{54363E9B-3A5A-46D6-9ACA-3F1626572647}.Debug - Copy To Paratext|x64.Build.0 = Debug - Copy To Paratext|x64
 		{54363E9B-3A5A-46D6-9ACA-3F1626572647}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -178,7 +179,8 @@ Global
 		{884A12C9-4F3B-4861-A4F2-CA3309C49C2E}.Release|Any CPU.Build.0 = Release|Any CPU
 		{884A12C9-4F3B-4861-A4F2-CA3309C49C2E}.Release|x64.ActiveCfg = Release|x64
 		{884A12C9-4F3B-4861-A4F2-CA3309C49C2E}.Release|x64.Build.0 = Release|x64
-		{D5CF7D63-5DE2-450A-B1AF-3A6FC0459508}.Debug - Copy To Paratext|Any CPU.ActiveCfg = Debug|x86
+		{D5CF7D63-5DE2-450A-B1AF-3A6FC0459508}.Debug - Copy To Paratext|Any CPU.ActiveCfg = Debug|Any CPU
+		{D5CF7D63-5DE2-450A-B1AF-3A6FC0459508}.Debug - Copy To Paratext|Any CPU.Build.0 = Debug|Any CPU
 		{D5CF7D63-5DE2-450A-B1AF-3A6FC0459508}.Debug - Copy To Paratext|x64.ActiveCfg = Debug|x64
 		{D5CF7D63-5DE2-450A-B1AF-3A6FC0459508}.Debug - Copy To Paratext|x64.Build.0 = Debug|x64
 		{D5CF7D63-5DE2-450A-B1AF-3A6FC0459508}.Debug|Any CPU.ActiveCfg = Debug|Any CPU

--- a/Transcelerator/Transcelerator.csproj
+++ b/Transcelerator/Transcelerator.csproj
@@ -5,7 +5,7 @@
   <Import Project="..\packages\SIL.ReleaseTasks.2.5.0\build\SIL.ReleaseTasks.props" Condition="Exists('..\packages\SIL.ReleaseTasks.2.5.0\build\SIL.ReleaseTasks.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
     <ProductVersion>9.0.30729</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{3A4BF2AF-23B5-487E-BEA5-5D65A0A01BF7}</ProjectGuid>

--- a/Transcelerator/TransceleratorTests/TransceleratorTests.csproj
+++ b/Transcelerator/TransceleratorTests/TransceleratorTests.csproj
@@ -4,7 +4,7 @@
   <Import Project="..\..\packages\icu.net.2.8.1\build\icu.net.props" Condition="Exists('..\..\packages\icu.net.2.8.1\build\icu.net.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
     <ProductVersion>9.0.30729</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{DB5B6E93-353D-4C21-92F1-F9BF83F173E4}</ProjectGuid>

--- a/TxlCore/TxlCore.csproj
+++ b/TxlCore/TxlCore.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\packages\icu.net.2.8.1\build\icu.net.props" Condition="Exists('..\packages\icu.net.2.8.1\build\icu.net.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
     <ProductVersion>9.0.30729</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{140A72D9-B0B3-4E19-AA3B-0127C3014D39}</ProjectGuid>

--- a/TxlCore/TxlCoreTests/TxlCoreTests.csproj
+++ b/TxlCore/TxlCoreTests/TxlCoreTests.csproj
@@ -4,7 +4,7 @@
   <Import Project="..\..\packages\icu.net.2.8.1\build\icu.net.props" Condition="Exists('..\..\packages\icu.net.2.8.1\build\icu.net.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
     <ProductVersion>9.0.30729</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{884A12C9-4F3B-4861-A4F2-CA3309C49C2E}</ProjectGuid>

--- a/TxlMasterQuestionPreProcessor/TxlMasterQuestionPreProcessor.csproj
+++ b/TxlMasterQuestionPreProcessor/TxlMasterQuestionPreProcessor.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\packages\icu.net.2.8.1\build\icu.net.props" Condition="Exists('..\packages\icu.net.2.8.1\build\icu.net.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
     <ProductVersion>9.0.30729</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{54363E9B-3A5A-46D6-9ACA-3F1626572647}</ProjectGuid>

--- a/TxlMasterQuestionPreProcessor/TxlMasterQuestionPreProcessorTests/TxlMasterQuestionPreProcessorTests.csproj
+++ b/TxlMasterQuestionPreProcessor/TxlMasterQuestionPreProcessorTests/TxlMasterQuestionPreProcessorTests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\packages\NUnit.3.13.3\build\NUnit.props" Condition="Exists('..\..\packages\NUnit.3.13.3\build\NUnit.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
     <ProductVersion>9.0.30729</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{6DE38973-4256-4AD7-A48F-56675CA826E2}</ProjectGuid>


### PR DESCRIPTION
These changes are mainly to make VS Code happier (precursor to merging in the Platform.Bible extension template:
Made all projects default to building for the x64 platform if no configuration is specified.
Fixed mistake in Transcelerator.sln where Any CPU configuration was building a couple projects as x86

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/Transcelerator/118)
<!-- Reviewable:end -->
