### PR TITLE
Eliminated warnings and streamlined build

### DIFF
--- a/DataIntegrityTests/DataIntegrityTests.csproj
+++ b/DataIntegrityTests/DataIntegrityTests.csproj
@@ -39,9 +39,6 @@
       <Version>3.8.1</Version>
     </PackageReference>
     <PackageReference Include="nunit" Version="3.14.0" />
-    <PackageReference Include="NUnit.ConsoleRunner">
-      <Version>3.19.1</Version>
-    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="SIL.Scripture" Version="15.0.0" />
@@ -50,6 +47,7 @@
     </PackageReference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Security" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/Installer/CustomInstallerActions/Properties/AssemblyInfo.cs
+++ b/Installer/CustomInstallerActions/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("SIL")]
 [assembly: AssemblyProduct("CustomInstallerActions")]
-[assembly: AssemblyCopyright("Copyright © 2017, SIL International")]
+[assembly: AssemblyCopyright("Copyright © 2017-2025, SIL Global")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Installer/Installer.wxs
+++ b/Installer/Installer.wxs
@@ -239,12 +239,6 @@ http://blogs.msdn.com/robmen/archive/2003/10/04/56479.aspx -->
             <File Id="System.Resources.Extensions.dll_P9" ShortName="4m4f3iii.dll" KeyPath="yes" Name="System.Resources.Extensions.dll" />
           </Component>
           <Component Guid="*">
-            <File Id="System.Text.Encodings.Web.dll_P9" ShortName="systxenc.dll" KeyPath="yes" Name="System.Text.Encodings.Web.dll" />
-          </Component>
-          <Component Guid="*">
-            <File Id="System.Text.Json.dll_P9" ShortName="systjson.dll" KeyPath="yes" Name="System.Text.Json.dll" />
-          </Component>
-          <Component Guid="*">
             <File Id="System.Threading.Tasks.Extensions.dll_P9" ShortName="systtext.dll" KeyPath="yes" Name="System.Threading.Tasks.Extensions.dll" />
           </Component>
           <Component Guid="*">
@@ -395,6 +389,9 @@ http://blogs.msdn.com/robmen/archive/2003/10/04/56479.aspx -->
           </Component>
           <Component Guid="*">
             <File Id="System.Resources.Extensions.dll_P9Beta" ShortName="zvzi6010.dll" KeyPath="yes" Name="System.Resources.Extensions.dll" />
+          </Component>
+          <Component Guid="*">
+            <File Id="System.Threading.Tasks.Extensions.dll_P9Beta" ShortName="sy1ttbp9.dll" KeyPath="yes" Name="System.Threading.Tasks.Extensions.dll" />
           </Component>
           <Component Guid="*">
             <File Id="System.ValueTuple.dll_P9Beta" ShortName="jp96u9at.dll" KeyPath="yes" Name="System.ValueTuple.dll" />

--- a/Transcelerator/CreditsAndLicense.htm
+++ b/Transcelerator/CreditsAndLicense.htm
@@ -28,12 +28,12 @@
       <p>Some questions for Proverbs were provided with no licensing restrictions by Kevin Edgerton.</p>
       <p>Answers designated [NET©] indicate quotations from the NET Bible® copyright ©1996-2016 by Biblical Studies Press, L.L.C. <a href="http://netbible.com">http://netbible.com</a> All rights reserved.</p>
       <p>Answers designated [TH] indicate quotations from the <a href="http://www.ubs-translations.org/cat/helps_for_translators/handbooks/english_series/">UBS Translator's Handbook series</a>, copyright United Bible Societies.</p>
-      <p>Answers designated [TNN] indicate quotations from the <a href="https://www.sil.org/resources/publications/notes">SIL Translator’s Notes</a>, copyright SIL International.</p>
+      <p>Answers designated [TNN] indicate quotations from the <a href="https://www.sil.org/resources/publications/notes">SIL Translator’s Notes</a>, copyright SIL Global.</p>
       <p>Thanks to Jennifer Denning Carlson for her help with the alternate form overrides.</p>
 
       <h1>License</h1>
       <p>This software and the resources it contains are licensed under <a href="http://sil.mit-license.org/">The MIT License</a>.</p>
-      <p>Copyright © 2011-2025, SIL International</p>
+      <p>Copyright © 2011-2025, SIL Global</p>
       <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:</p>
       <p>The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.</p>
       <p>THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>

--- a/Transcelerator/CreditsAndLicense.htm
+++ b/Transcelerator/CreditsAndLicense.htm
@@ -33,7 +33,7 @@
 
       <h1>License</h1>
       <p>This software and the resources it contains are licensed under <a href="http://sil.mit-license.org/">The MIT License</a>.</p>
-      <p>Copyright © 2011-2024, SIL International</p>
+      <p>Copyright © 2011-2025, SIL International</p>
       <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:</p>
       <p>The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.</p>
       <p>THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>

--- a/Transcelerator/Properties/AssemblyInfo.cs
+++ b/Transcelerator/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("SIL")]
 [assembly: AssemblyProduct("Transcelerator")]
-[assembly: AssemblyCopyright("Copyright © 2011-2024, SIL International")]
+[assembly: AssemblyCopyright("Copyright © 2011-2025, SIL Global")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Transcelerator/Transcelerator.csproj
+++ b/Transcelerator/Transcelerator.csproj
@@ -129,9 +129,6 @@
     <Reference Include="Markdig.Signed, Version=0.40.0.0, Culture=neutral, PublicKeyToken=870da25a133885f8, processorArchitecture=MSIL">
       <HintPath>..\packages\Markdig.Signed.0.40.0\lib\net462\Markdig.Signed.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.8.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build.Tasks.v4.0" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />

--- a/Transcelerator/Transcelerator.csproj
+++ b/Transcelerator/Transcelerator.csproj
@@ -279,12 +279,6 @@
     </Reference>
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.ServiceProcess" />
-    <Reference Include="System.Text.Encodings.Web, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Encodings.Web.8.0.0\lib\net462\System.Text.Encodings.Web.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Text.Json, Version=8.0.0.5, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Json.8.0.5\lib\net462\System.Text.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.6.0\lib\net462\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>

--- a/Transcelerator/Transcelerator.csproj
+++ b/Transcelerator/Transcelerator.csproj
@@ -126,8 +126,8 @@
     <Reference Include="L10NSharp, Version=7.0.0.0, Culture=neutral, PublicKeyToken=fd0b3e309a5b7c28, processorArchitecture=MSIL">
       <HintPath>..\packages\L10NSharp.7.0.0\lib\net461\L10NSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Markdig.Signed, Version=0.37.0.0, Culture=neutral, PublicKeyToken=870da25a133885f8, processorArchitecture=MSIL">
-      <HintPath>..\packages\Markdig.Signed.0.37.0\lib\net462\Markdig.Signed.dll</HintPath>
+    <Reference Include="Markdig.Signed, Version=0.40.0.0, Culture=neutral, PublicKeyToken=870da25a133885f8, processorArchitecture=MSIL">
+      <HintPath>..\packages\Markdig.Signed.0.40.0\lib\net462\Markdig.Signed.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.8.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
@@ -276,9 +276,6 @@
     <Reference Include="System.Security.Cryptography.Algorithms" />
     <Reference Include="System.Security.Cryptography.Encoding" />
     <Reference Include="System.Security.Cryptography.Primitives" />
-    <Reference Include="System.Security.Cryptography.ProtectedData, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.ProtectedData.8.0.0\lib\net462\System.Security.Cryptography.ProtectedData.dll</HintPath>
-    </Reference>
     <Reference Include="System.Security.Cryptography.X509Certificates" />
     <Reference Include="System.Security.Permissions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Permissions.8.0.0\lib\net462\System.Security.Permissions.dll</HintPath>

--- a/Transcelerator/TransceleratorTests/App.config
+++ b/Transcelerator/TransceleratorTests/App.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<configSections>
 		<sectionGroup name="NUnit">
@@ -68,7 +68,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Markdig.Signed" publicKeyToken="870da25a133885f8" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.37.0.0" newVersion="0.37.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.40.0.0" newVersion="0.40.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/Transcelerator/TransceleratorTests/App.config
+++ b/Transcelerator/TransceleratorTests/App.config
@@ -75,20 +75,12 @@
         <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.5" newVersion="8.0.0.5" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.0.0.2" newVersion="8.0.0.2" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="TagLibSharp" publicKeyToken="db62eba44689b5b0" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/Transcelerator/TransceleratorTests/Properties/AssemblyInfo.cs
+++ b/Transcelerator/TransceleratorTests/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("SIL")]
 [assembly: AssemblyProduct("Transcelerator")]
-[assembly: AssemblyCopyright("Copyright © 2011-2022 SIL International")]
+[assembly: AssemblyCopyright("Copyright © 2011-2025 SIL Global")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Transcelerator/TransceleratorTests/TransceleratorTests.csproj
+++ b/Transcelerator/TransceleratorTests/TransceleratorTests.csproj
@@ -233,12 +233,6 @@
     </Reference>
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.ServiceProcess" />
-    <Reference Include="System.Text.Encodings.Web, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Text.Encodings.Web.8.0.0\lib\net462\System.Text.Encodings.Web.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Text.Json, Version=8.0.0.5, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Text.Json.8.0.5\lib\net462\System.Text.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.6.0\lib\net462\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>

--- a/Transcelerator/TransceleratorTests/TransceleratorTests.csproj
+++ b/Transcelerator/TransceleratorTests/TransceleratorTests.csproj
@@ -102,8 +102,8 @@
     <Reference Include="L10NSharp, Version=7.0.0.0, Culture=neutral, PublicKeyToken=fd0b3e309a5b7c28, processorArchitecture=MSIL">
       <HintPath>..\..\packages\L10NSharp.7.0.0\lib\net461\L10NSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Markdig.Signed, Version=0.37.0.0, Culture=neutral, PublicKeyToken=870da25a133885f8, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Markdig.Signed.0.37.0\lib\net462\Markdig.Signed.dll</HintPath>
+    <Reference Include="Markdig.Signed, Version=0.40.0.0, Culture=neutral, PublicKeyToken=870da25a133885f8, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Markdig.Signed.0.40.0\lib\net462\Markdig.Signed.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Bcl.AsyncInterfaces.8.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
@@ -226,9 +226,6 @@
     <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
       <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Security.Cryptography.ProtectedData, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Security.Cryptography.ProtectedData.7.0.0\lib\netstandard2.0\System.Security.Cryptography.ProtectedData.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.2, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Security.Cryptography.X509Certificates.4.3.2\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>

--- a/Transcelerator/TransceleratorTests/TransceleratorTests.csproj
+++ b/Transcelerator/TransceleratorTests/TransceleratorTests.csproj
@@ -105,9 +105,6 @@
     <Reference Include="Markdig.Signed, Version=0.40.0.0, Culture=neutral, PublicKeyToken=870da25a133885f8, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Markdig.Signed.0.40.0\lib\net462\Markdig.Signed.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Bcl.AsyncInterfaces.8.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Extensions.DependencyModel, Version=8.0.0.2, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.DependencyModel.8.0.2\lib\net462\Microsoft.Extensions.DependencyModel.dll</HintPath>

--- a/Transcelerator/TransceleratorTests/packages.config
+++ b/Transcelerator/TransceleratorTests/packages.config
@@ -12,7 +12,7 @@
   <package id="icu.net" version="3.0.0" targetFramework="net48" />
   <package id="JetBrains.Annotations" version="2024.3.0" targetFramework="net48" />
   <package id="L10NSharp" version="7.0.0" targetFramework="net48" />
-  <package id="Markdig.Signed" version="0.37.0" targetFramework="net48" />
+  <package id="Markdig.Signed" version="0.40.0" targetFramework="net48" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="net48" />
   <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net48" />
   <package id="Microsoft.DotNet.PlatformAbstractions" version="3.1.6" targetFramework="net461" />
@@ -30,7 +30,6 @@
   <package id="NDesk.DBus" version="0.15.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net48" />
   <package id="NUnit" version="3.14.0" targetFramework="net48" />
-  <package id="NUnit.ConsoleRunner" version="3.19.1" targetFramework="net48" />
   <package id="PangoSharp" version="3.24.24.95" targetFramework="net48" />
   <package id="ParatextCorePluginInterfaces" version="2.0.100" targetFramework="net48" />
   <package id="ParatextPluginInterfaces" version="2.0.100" targetFramework="net48" />

--- a/Transcelerator/app.config
+++ b/Transcelerator/app.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <configSections>
         <sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
@@ -326,10 +326,6 @@
       <dependentAssembly>
         <assemblyIdentity name="TagLibSharp" publicKeyToken="db62eba44689b5b0" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/Transcelerator/app.config
+++ b/Transcelerator/app.config
@@ -293,7 +293,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Markdig.Signed" publicKeyToken="870da25a133885f8" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.37.0.0" newVersion="0.37.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.40.0.0" newVersion="0.40.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/Transcelerator/app.config
+++ b/Transcelerator/app.config
@@ -300,10 +300,6 @@
         <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.5" newVersion="8.0.0.5" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="SIL.Windows.Forms" publicKeyToken="cab3c8c5232dfcf2" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
       </dependentAssembly>
@@ -326,10 +322,6 @@
       <dependentAssembly>
         <assemblyIdentity name="TagLibSharp" publicKeyToken="db62eba44689b5b0" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/Transcelerator/packages.config
+++ b/Transcelerator/packages.config
@@ -22,7 +22,7 @@
   <package id="Icu4c.Win.Min" version="62.2.1-beta" targetFramework="net48" />
   <package id="JetBrains.Annotations" version="2024.3.0" targetFramework="net48" />
   <package id="L10NSharp" version="7.0.0" targetFramework="net48" />
-  <package id="Markdig.Signed" version="0.37.0" targetFramework="net48" />
+  <package id="Markdig.Signed" version="0.40.0" targetFramework="net48" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="net48" />
   <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net48" />
   <package id="Microsoft.DotNet.PlatformAbstractions" version="3.1.6" targetFramework="net48" />
@@ -74,7 +74,6 @@
   <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net48" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net48" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net48" />
-  <package id="System.Security.Cryptography.ProtectedData" version="8.0.0" targetFramework="net48" />
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net48" />
   <package id="System.Security.Permissions" version="8.0.0" targetFramework="net48" />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net48" />

--- a/TxlData/TxlDataTests/TxlDataTests.csproj
+++ b/TxlData/TxlDataTests/TxlDataTests.csproj
@@ -34,14 +34,6 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Text.Encodings.Web, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
-      <HintPath>..\packages\System.Text.Encodings.Web.8.0.0\lib\net462\System.Text.Encodings.Web.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Text.Json, Version=8.0.0.5, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
-      <HintPath>..\packages\System.Text.Json.8.0.5\lib\net462\System.Text.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/TxlData/TxlDataTests/TxlDataTests.csproj
+++ b/TxlData/TxlDataTests/TxlDataTests.csproj
@@ -31,10 +31,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.8.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />

--- a/TxlData/TxlDataTests/TxlDataTests.csproj
+++ b/TxlData/TxlDataTests/TxlDataTests.csproj
@@ -42,8 +42,8 @@
       <HintPath>..\packages\System.Text.Encodings.Web.8.0.0\lib\net462\System.Text.Encodings.Web.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Text.Json, Version=8.0.0.4, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
-      <HintPath>..\packages\System.Text.Json.8.0.4\lib\net462\System.Text.Json.dll</HintPath>
+    <Reference Include="System.Text.Json, Version=8.0.0.5, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+      <HintPath>..\packages\System.Text.Json.8.0.5\lib\net462\System.Text.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/TxlData/TxlDataTests/TxlDataTests.csproj
+++ b/TxlData/TxlDataTests/TxlDataTests.csproj
@@ -78,9 +78,6 @@
     <PackageReference Include="NUnit">
       <Version>3.14.0</Version>
     </PackageReference>
-    <PackageReference Include="NUnit.ConsoleRunner">
-      <Version>3.19.1</Version>
-    </PackageReference>
     <PackageReference Include="ParatextCorePluginInterfaces">
       <Version>2.0.100</Version>
     </PackageReference>

--- a/TxlData/TxlDataTests/packages.config
+++ b/TxlData/TxlDataTests/packages.config
@@ -34,7 +34,7 @@
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net48" />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net461" />
   <package id="System.Text.Encodings.Web" version="8.0.0" targetFramework="net48" />
-  <package id="System.Text.Json" version="8.0.4" targetFramework="net48" />
+  <package id="System.Text.Json" version="8.0.5" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
 </packages>

--- a/TxlMasterQuestionPreProcessor/Properties/AssemblyInfo.cs
+++ b/TxlMasterQuestionPreProcessor/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("SIL")]
 [assembly: AssemblyProduct("Transcelerator")]
-[assembly: AssemblyCopyright("Copyright © 2013 SIL International")]
+[assembly: AssemblyCopyright("Copyright © 2013-2025 SIL Global")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/TxlMasterQuestionPreProcessor/TxlMasterQuestionPreProcessor.csproj
+++ b/TxlMasterQuestionPreProcessor/TxlMasterQuestionPreProcessor.csproj
@@ -101,9 +101,6 @@
     <Reference Include="Markdig.Signed, Version=0.40.0.0, Culture=neutral, PublicKeyToken=870da25a133885f8, processorArchitecture=MSIL">
       <HintPath>..\packages\Markdig.Signed.0.40.0\lib\net462\Markdig.Signed.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.8.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Extensions.DependencyModel, Version=8.0.0.2, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.DependencyModel.8.0.2\lib\net462\Microsoft.Extensions.DependencyModel.dll</HintPath>

--- a/TxlMasterQuestionPreProcessor/TxlMasterQuestionPreProcessor.csproj
+++ b/TxlMasterQuestionPreProcessor/TxlMasterQuestionPreProcessor.csproj
@@ -206,8 +206,8 @@
       <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Security.Cryptography.ProtectedData, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.ProtectedData.7.0.0\lib\netstandard2.0\System.Security.Cryptography.ProtectedData.dll</HintPath>
+    <Reference Include="System.Security.Cryptography.ProtectedData, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.ProtectedData.8.0.0\lib\net462\System.Security.Cryptography.ProtectedData.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.2, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.2\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>

--- a/TxlMasterQuestionPreProcessor/TxlMasterQuestionPreProcessor.csproj
+++ b/TxlMasterQuestionPreProcessor/TxlMasterQuestionPreProcessor.csproj
@@ -223,12 +223,6 @@
     </Reference>
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.ServiceProcess" />
-    <Reference Include="System.Text.Encodings.Web, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Encodings.Web.8.0.0\lib\net462\System.Text.Encodings.Web.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Text.Json, Version=8.0.0.5, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Json.8.0.5\lib\net462\System.Text.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.6.0\lib\net462\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>

--- a/TxlMasterQuestionPreProcessor/TxlMasterQuestionPreProcessor.csproj
+++ b/TxlMasterQuestionPreProcessor/TxlMasterQuestionPreProcessor.csproj
@@ -98,8 +98,8 @@
     <Reference Include="L10NSharp, Version=7.0.0.0, Culture=neutral, PublicKeyToken=fd0b3e309a5b7c28, processorArchitecture=MSIL">
       <HintPath>..\packages\L10NSharp.7.0.0\lib\net461\L10NSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Markdig.Signed, Version=0.37.0.0, Culture=neutral, PublicKeyToken=870da25a133885f8, processorArchitecture=MSIL">
-      <HintPath>..\packages\Markdig.Signed.0.37.0\lib\net462\Markdig.Signed.dll</HintPath>
+    <Reference Include="Markdig.Signed, Version=0.40.0.0, Culture=neutral, PublicKeyToken=870da25a133885f8, processorArchitecture=MSIL">
+      <HintPath>..\packages\Markdig.Signed.0.40.0\lib\net462\Markdig.Signed.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.8.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
@@ -216,9 +216,6 @@
     <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
       <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Security.Cryptography.ProtectedData, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.ProtectedData.8.0.0\lib\net462\System.Security.Cryptography.ProtectedData.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.2, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.2\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>

--- a/TxlMasterQuestionPreProcessor/TxlMasterQuestionPreProcessorTests/Properties/AssemblyInfo.cs
+++ b/TxlMasterQuestionPreProcessor/TxlMasterQuestionPreProcessorTests/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("SIL")]
 [assembly: AssemblyProduct("Transcelerator")]
-[assembly: AssemblyCopyright("Copyright © 2013 SIL International")]
+[assembly: AssemblyCopyright("Copyright © 2013-2025 SIL Global")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/TxlMasterQuestionPreProcessor/TxlMasterQuestionPreProcessorTests/app.config
+++ b/TxlMasterQuestionPreProcessor/TxlMasterQuestionPreProcessorTests/app.config
@@ -44,7 +44,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Markdig.Signed" publicKeyToken="870da25a133885f8" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.37.0.0" newVersion="0.37.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.40.0.0" newVersion="0.40.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/TxlMasterQuestionPreProcessor/TxlMasterQuestionPreProcessorTests/app.config
+++ b/TxlMasterQuestionPreProcessor/TxlMasterQuestionPreProcessorTests/app.config
@@ -52,7 +52,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.3" newVersion="8.0.0.3" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.5" newVersion="8.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="TagLibSharp" publicKeyToken="db62eba44689b5b0" culture="neutral" />

--- a/TxlMasterQuestionPreProcessor/TxlMasterQuestionPreProcessorTests/app.config
+++ b/TxlMasterQuestionPreProcessor/TxlMasterQuestionPreProcessorTests/app.config
@@ -51,16 +51,8 @@
         <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.5" newVersion="8.0.0.5" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="TagLibSharp" publicKeyToken="db62eba44689b5b0" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/TxlMasterQuestionPreProcessor/TxlMasterQuestionPreProcessorTests/packages.config
+++ b/TxlMasterQuestionPreProcessor/TxlMasterQuestionPreProcessorTests/packages.config
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="3.14.0" targetFramework="net48" />
-  <package id="NUnit.ConsoleRunner" version="3.19.1" targetFramework="net48" />
   <package id="System.IO" version="4.3.0" targetFramework="net48" />
   <package id="System.Net.Http" version="4.3.4" targetFramework="net48" />
   <package id="System.Runtime" version="4.3.1" targetFramework="net48" />

--- a/TxlMasterQuestionPreProcessor/app.config
+++ b/TxlMasterQuestionPreProcessor/app.config
@@ -60,7 +60,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.3" newVersion="8.0.0.3" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.5" newVersion="8.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="TagLibSharp" publicKeyToken="db62eba44689b5b0" culture="neutral" />

--- a/TxlMasterQuestionPreProcessor/app.config
+++ b/TxlMasterQuestionPreProcessor/app.config
@@ -52,7 +52,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Markdig.Signed" publicKeyToken="870da25a133885f8" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.37.0.0" newVersion="0.37.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.40.0.0" newVersion="0.40.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/TxlMasterQuestionPreProcessor/app.config
+++ b/TxlMasterQuestionPreProcessor/app.config
@@ -59,16 +59,8 @@
         <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.5" newVersion="8.0.0.5" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="TagLibSharp" publicKeyToken="db62eba44689b5b0" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/TxlMasterQuestionPreProcessor/packages.config
+++ b/TxlMasterQuestionPreProcessor/packages.config
@@ -12,7 +12,7 @@
   <package id="icu.net" version="3.0.0" targetFramework="net48" />
   <package id="JetBrains.Annotations" version="2024.3.0" targetFramework="net48" />
   <package id="L10NSharp" version="7.0.0" targetFramework="net48" />
-  <package id="Markdig.Signed" version="0.37.0" targetFramework="net48" />
+  <package id="Markdig.Signed" version="0.40.0" targetFramework="net48" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="net48" />
   <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net48" />
   <package id="Microsoft.DotNet.PlatformAbstractions" version="3.1.6" targetFramework="net461" />
@@ -54,7 +54,6 @@
   <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net48" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net48" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net48" />
-  <package id="System.Security.Cryptography.ProtectedData" version="8.0.0" targetFramework="net48" />
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net48" />
   <package id="System.Security.Permissions" version="8.0.0" targetFramework="net48" />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net461" />

--- a/TxlMasterQuestionPreProcessor/packages.config
+++ b/TxlMasterQuestionPreProcessor/packages.config
@@ -54,6 +54,7 @@
   <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net48" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net48" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net48" />
+  <package id="System.Security.Cryptography.ProtectedData" version="8.0.0" targetFramework="net48" />
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net48" />
   <package id="System.Security.Permissions" version="8.0.0" targetFramework="net48" />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net461" />

--- a/TxlShared/TxlSharedTests/TxlSharedTests.csproj
+++ b/TxlShared/TxlSharedTests/TxlSharedTests.csproj
@@ -60,9 +60,6 @@
     <PackageReference Include="NUnit">
       <Version>3.14.0</Version>
     </PackageReference>
-    <PackageReference Include="NUnit.ConsoleRunner">
-      <Version>3.19.1</Version>
-    </PackageReference>
     <PackageReference Include="SIL.TestUtilities">
       <Version>15.0.0</Version>
     </PackageReference>

--- a/build/Transcelerator.proj
+++ b/build/Transcelerator.proj
@@ -5,31 +5,25 @@
 		<OutputDir>$(RootDir)/output</OutputDir>
 		<BUILD_NUMBER Condition="'$(BUILD_NUMBER)'==''">0.0.0.0</BUILD_NUMBER>
 		<PackagesDir>$(RootDir)/packages</PackagesDir>
-		<NunitConsoleRunnerDir>$(PackagesDir)/NUnit.ConsoleRunner.3.19.1/tools</NunitConsoleRunnerDir>
-		<BuildTasksDll>$(PackagesDir)/SIL.BuildTasks/tools/SIL.BuildTasks.dll</BuildTasksDll>
+		<NunitConsoleRunnerDir>$(PackagesDir)/NUnit.ConsoleRunner/tools</NunitConsoleRunnerDir>
+		<SILBuildTasksProps>$(PackagesDir)/SIL.BuildTasks/build/SIL.BuildTasks.props</SILBuildTasksProps>
 		<SILReleaseTasksProps>$(PackagesDir)/SIL.ReleaseTasks/build/SIL.ReleaseTasks.props</SILReleaseTasksProps>
 		<Solution>Transcelerator.sln</Solution>
 		<ApplicationName>Transcelerator</ApplicationName>
 		<Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
 		<TeamCity Condition="'$(teamcity_version)' != ''">true</TeamCity>
 		<TeamCity Condition="'$(teamcity_version)' == ''">false</TeamCity>
+		<NUnitProjectLoaderDll>$(PackagesDir)/NUnit.Extension.NUnitProjectLoader/tools/nunit-project-loader.dll</NUnitProjectLoaderDll>
+		<TeamCityEventListenerDll>$(PackagesDir)/NUnit.Extension.TeamCityEventListener/tools/teamcity-event-listener.dll</TeamCityEventListenerDll>
 		<TestOutputXmlFile Condition="'$(teamcity_version)' == ''">$(OutputDir)/$(Configuration)/TestResults.xml</TestOutputXmlFile>
 		<ExtraExcludeCategories Condition="'$(teamcity_version)' != ''">SkipOnTeamCity,</ExtraExcludeCategories>
-		<RestartBuild Condition="!Exists('$(BuildTasksDll)') Or !Exists('$(SILReleaseTasksProps)') Or !Exists('$(NunitConsoleRunnerDir)/nunit3-console.exe') Or !Exists('$(RootDir)/NUnit.Extension.NUnitProjectLoader/tools/nunit-project-loader.dll') Or !Exists('$(RootDir)/NUnit.Extension.TeamCityEventListener/tools/teamcity-event-listener.dll')">true</RestartBuild>
-		<RestartBuild Condition="Exists('$(BuildTasksDll)') And Exists('$(SILReleaseTasksProps)') And Exists('$(NunitConsoleRunnerDir)/nunit3-console.exe') And Exists('$(RootDir)/NUnit.Extension.NUnitProjectLoader/tools/nunit-project-loader.dll') And Exists('$(RootDir)/NUnit.Extension.TeamCityEventListener/tools/teamcity-event-listener.dll')">false</RestartBuild>
+		<RestartBuild Condition="!Exists('$(SILBuildTasksProps)') Or !Exists('$(SILReleaseTasksProps)') Or !Exists('$(NunitConsoleRunnerDir)/nunit3-console.exe') Or !Exists('$(NUnitProjectLoaderDll)') Or !Exists('$(TeamCityEventListenerDll)')">true</RestartBuild>
+		<RestartBuild Condition="Exists('$(SILBuildTasksProps)') And Exists('$(SILReleaseTasksProps)') And Exists('$(NunitConsoleRunnerDir)/nunit3-console.exe') And Exists('$(NUnitProjectLoaderDll)') And Exists('$(TeamCityEventListenerDll)')">false</RestartBuild>
 		<Platform>x64</Platform>
 	</PropertyGroup>
-
-	<UsingTask TaskName="StampAssemblies" AssemblyFile="$(BuildTasksDll)"
-		Condition="Exists('$(BuildTasksDll)')" />
-	<UsingTask TaskName="MakeWixForDirTree" AssemblyFile="$(BuildTasksDll)"
-		Condition="Exists('$(BuildTasksDll)')" />
-	<UsingTask TaskName="Split" AssemblyFile="$(BuildTasksDll)" Condition="Exists('$(BuildTasksDll)')" />
-	<UsingTask TaskName="FileUpdate" AssemblyFile="$(BuildTasksDll)" Condition="Exists('$(BuildTasksDll)')" />
-	<UsingTask TaskName="NUnit3" AssemblyFile="$(BuildTasksDll)" Condition="Exists('$(BuildTasksDll)')" />
   
 	<Target Name="VersionNumbers">
-		<Message Text="BuildTasksDll: $(BuildTasksDll)"/>
+		<Message Text="SILBuildTasksProps: $(SILBuildTasksProps)"/>
 		<Message Text="BUILD_NUMBER: $(BUILD_NUMBER)" Importance="high"/>
 
 		<Split Input="$(BUILD_NUMBER)" Delimiter="." OutputSubString="2">
@@ -64,11 +58,7 @@
 	
 	<Import Project="../.nuget/NuGet.targets" />
 	<Import Project="$(SILReleaseTasksProps)" Condition="Exists('$(SILReleaseTasksProps)')" />
-
-	<ItemGroup>
-		<PackageDirs Include="$([System.IO.Directory]::GetDirectories(`$(PackagesDir)/`, `NUnit.Console*`, SearchOption.TopDirectoryOnly))" Condition="Exists('$(PackagesDir)/')" />
-		<PackageDirs Include="$([System.IO.Directory]::GetDirectories(`$(PackagesDir)/`, `NUnit.Extension.*`, SearchOption.TopDirectoryOnly))" Condition="Exists('$(PackagesDir)/')" />
-	</ItemGroup>
+	<Import Project="$(SILBuildTasksProps)" Condition="Exists('$(SILBuildTasksProps)')" />
 
 	<ItemGroup>
 		<_ExcludeEnDir Include="$(RootDir)/Docs/Help Topics/en" />
@@ -110,16 +100,15 @@
 	<Target Name="RestoreLocalPackages" DependsOnTargets="CheckPrerequisites">
 		<Message Text="RestartBuild=$(RestartBuild)"/>
 		<Message Text="Configuration=$(Configuration)"/>
-		<!-- first remove any existing packages - if they were installed with appended version numbers nuget refuses to install it again, messing up things -->
-		<RemoveDir Directories="@(PackageDirs)" />
 		<Message Text="Calling $(NuGetCommand) restore ../$(Solution)" />
 		<Exec Command='$(NuGetCommand) restore ../$(Solution)' />
+		<Exec Command='$(NuGetCommand) install Markdig.Signed -source "$(PackageSources)" -solutionDirectory "$(SolutionDir)."' />
 		<Exec Command='$(NuGetCommand) install SIL.BuildTasks -excludeVersion -PreRelease -source "$(PackageSources)" -solutionDirectory "$(SolutionDir)."' />
 		<Exec Command='$(NuGetCommand) install SIL.ReleaseTasks -excludeVersion -PreRelease -source "$(PackageSources)" -solutionDirectory "$(SolutionDir)."' />
-		<Exec Command='$(NuGetCommand) install NUnit.ConsoleRunner -excludeVersion -version 3.19.1 -solutionDirectory "$(RootDir)"' />
+		<Exec Command='$(NuGetCommand) install NUnit.ConsoleRunner -excludeVersion -solutionDirectory "$(RootDir)"' />
 		<!-- The two extensions are required to show the tests on TC -->
-		<Exec Command='$(NuGetCommand) install NUnit.Extension.NUnitProjectLoader -excludeVersion -version 3.6.0 -solutionDirectory "$(RootDir)"' />
-		<Exec Command='$(NuGetCommand) install NUnit.Extension.TeamCityEventListener -excludeVersion -version 1.0.7 -solutionDirectory "$(RootDir)"' />
+		<Exec Command='$(NuGetCommand) install NUnit.Extension.NUnitProjectLoader -excludeVersion -solutionDirectory "$(RootDir)"' />
+		<Exec Command='$(NuGetCommand) install NUnit.Extension.TeamCityEventListener -excludeVersion -solutionDirectory "$(RootDir)"' />
 
 		<MSBuild Projects="$(MSBuildProjectFullPath)" Targets="BuildInternal"
 		  Properties="Configuration=$(Configuration)" Condition="$(RestartBuild)" />

--- a/build/Transcelerator.proj
+++ b/build/Transcelerator.proj
@@ -111,7 +111,7 @@
 		<Exec Command='$(NuGetCommand) install NUnit.Extension.TeamCityEventListener -excludeVersion -solutionDirectory "$(RootDir)"' />
 
 		<MSBuild Projects="$(MSBuildProjectFullPath)" Targets="BuildInternal"
-		  Properties="Configuration=$(Configuration)" Condition="$(RestartBuild)" />
+		  Properties="Configuration=$(Configuration);RunCodeAnalysis=$(RunCodeAnalysis)" Condition="$(RestartBuild)" />
     </Target>
 
 	<Target Name="SetAssemblyVersion" DependsOnTargets="VersionNumbers">
@@ -133,7 +133,7 @@
 	<Target Name="BuildInternal" DependsOnTargets="SetAssemblyVersion">
 		<MSBuild Projects="$(RootDir)/$(Solution)"
 			 Targets="Rebuild"
-			 Properties="Configuration=%(Configurations.Identity)" />
+			 Properties="Configuration=%(Configurations.Identity);RunCodeAnalysis=$(RunCodeAnalysis)" />
 	</Target>
 
 	<Target Name="Test" DependsOnTargets="Build; SetTestAssemblies">


### PR DESCRIPTION
This is an attempt to eliminate this warning:
C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(2401,5): warning MSB3245: Could not resolve this reference. Could not locate the assembly "System.Security.Cryptography.ProtectedData, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL". Check to make sure the assembly exists on disk. If this reference is required by your code, you may get compilation errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/Transcelerator/153)
<!-- Reviewable:end -->
