### PR TITLE
Remove System.ValueTuple from installer

### DIFF
--- a/Installer/Installer.wxs
+++ b/Installer/Installer.wxs
@@ -232,9 +232,6 @@ http://blogs.msdn.com/robmen/archive/2003/10/04/56479.aspx -->
           <Component Guid="*">
             <File Id="System.Threading.Tasks.Extensions.dll_P9" ShortName="systtext.dll" KeyPath="yes" Name="System.Threading.Tasks.Extensions.dll" />
           </Component>
-          <Component Guid="*">
-            <File Id="System.ValueTuple.dll_P9" ShortName="nbqre2xf.dll" KeyPath="yes" Name="System.ValueTuple.dll" />
-          </Component>
         </ComponentGroup>
 
         <ComponentGroup Id="COMPONENTSFORP9BetaPLUGIN" Directory="INSTALLDIR9BETA" Source="..\Transcelerator\bin\x64\Release">
@@ -372,9 +369,6 @@ http://blogs.msdn.com/robmen/archive/2003/10/04/56479.aspx -->
           </Component>
           <Component Guid="*">
             <File Id="System.Threading.Tasks.Extensions.dll_P9Beta" ShortName="sy1ttbp9.dll" KeyPath="yes" Name="System.Threading.Tasks.Extensions.dll" />
-          </Component>
-          <Component Guid="*">
-            <File Id="System.ValueTuple.dll_P9Beta" ShortName="jp96u9at.dll" KeyPath="yes" Name="System.ValueTuple.dll" />
           </Component>
         </ComponentGroup>
 

--- a/Transcelerator/Transcelerator.csproj
+++ b/Transcelerator/Transcelerator.csproj
@@ -685,6 +685,11 @@ exit 1</PostBuildEvent>
     <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.3240.44\build\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.3240.44\build\Microsoft.Web.WebView2.targets'))" />
     <Error Condition="!Exists('..\packages\System.ValueTuple.4.6.1\build\net471\System.ValueTuple.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.ValueTuple.4.6.1\build\net471\System.ValueTuple.targets'))" />
   </Target>
+  <Target Name="ExcludeSystemValueTupleFromOutput" AfterTargets="ResolveAssemblyReferences">
+    <ItemGroup>
+      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="'%(Filename)' == 'System.ValueTuple'" />
+    </ItemGroup>
+  </Target>
   <Import Project="..\packages\NDesk.DBus.0.15.0\build\NDesk.DBus.targets" Condition="Exists('..\packages\NDesk.DBus.0.15.0\build\NDesk.DBus.targets')" />
   <Import Project="..\packages\Icu4c.Win.Min.62.2.1-beta\build\Icu4c.Win.Min.targets" Condition="Exists('..\packages\Icu4c.Win.Min.62.2.1-beta\build\Icu4c.Win.Min.targets')" />
   <Import Project="..\packages\Mono.Unix.7.1.0-final.1.21458.1\build\Mono.Unix.targets" Condition="Exists('..\packages\Mono.Unix.7.1.0-final.1.21458.1\build\Mono.Unix.targets')" />

--- a/TxlMasterQuestionPreProcessor/TxlMasterQuestionPreProcessor.csproj
+++ b/TxlMasterQuestionPreProcessor/TxlMasterQuestionPreProcessor.csproj
@@ -345,6 +345,11 @@ exit 1</PostBuildEvent>
     <Error Condition="!Exists('..\packages\SIL.Windows.Forms.16.0.0\build\SIL.Windows.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\SIL.Windows.Forms.16.0.0\build\SIL.Windows.Forms.targets'))" />
     <Error Condition="!Exists('..\packages\System.ValueTuple.4.6.1\build\net471\System.ValueTuple.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.ValueTuple.4.6.1\build\net471\System.ValueTuple.targets'))" />
   </Target>
+  <Target Name="ExcludeSystemValueTupleFromOutput" AfterTargets="ResolveAssemblyReferences">
+    <ItemGroup>
+      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="'%(Filename)' == 'System.ValueTuple'" />
+    </ItemGroup>
+  </Target>
   <Import Project="..\packages\NDesk.DBus.0.15.0\build\NDesk.DBus.targets" Condition="Exists('..\packages\NDesk.DBus.0.15.0\build\NDesk.DBus.targets')" />
   <Import Project="..\packages\Mono.Unix.7.1.0-final.1.21458.1\build\Mono.Unix.targets" Condition="Exists('..\packages\Mono.Unix.7.1.0-final.1.21458.1\build\Mono.Unix.targets')" />
   <Import Project="..\packages\GtkSharp.3.24.24.95\build\GtkSharp.targets" Condition="Exists('..\packages\GtkSharp.3.24.24.95\build\GtkSharp.targets')" />


### PR DESCRIPTION
It is not really needed since Paratext has it (same version) and it is not always being copied to bin on some agents (though I'd still like to know why it's not consistent).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/Transcelerator/167)
<!-- Reviewable:end -->
